### PR TITLE
Add "flattening" from SE3 to SE2.

### DIFF
--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -1162,21 +1162,33 @@ class SE3(SO3):
         else:
             return SE3([smb.trinv(x) for x in self.A], check=False)
 
-    def SE2(self) -> SE2:
+    def yaw_SE2(self, order: str = "zyx") -> SE2:
         """
-        Create SE(2) from SE(3)
+        Create SE(2) from SE(3) yaw angle.
 
-        :return: SE(2) with same rotation as the yaw angle using the 'zyx' convention,
-            and translation in x,y
+        :param order: angle sequence order, default to 'zyx'
+        :type order: str
+        :return: SE(2) with same rotation as the yaw angle using the roll-pitch-yaw convention,
+            and translation in x,y.
         :rtype: SE2 instance
 
-        "Flattens" 3D rigid-body motion to 2D, along the z axis.
+        Roll-pitch-yaw corresponds to successive rotations about the axes specified by ``order``:
+
+            - ``'zyx'`` [default], rotate by yaw about the z-axis, then by pitch about the new y-axis,
+              then by roll about the new x-axis.  Convention for a mobile robot with x-axis forward
+              and y-axis sideways.
+            - ``'xyz'``, rotate by yaw about the x-axis, then by pitch about the new y-axis,
+              then by roll about the new z-axis. Convention for a robot gripper with z-axis forward
+              and y-axis between the gripper fingers.
+            - ``'yxz'``, rotate by yaw about the y-axis, then by pitch about the new x-axis,
+              then by roll about the new z-axis. Convention for a camera with z-axis parallel
+              to the optic axis and x-axis parallel to the pixel rows.
 
         """
         if len(self) == 1:
-            return SE2(self.x, self.y, self.rpy()[2])
+            return SE2(self.x, self.y, self.rpy(order = order)[2])
         else:
-            return SE2([e.SE2() for e in self])
+            return SE2([e.yaw_SE2() for e in self])
 
     def delta(self, X2: Optional[SE3] = None) -> R6:
         r"""

--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -961,15 +961,7 @@ class SE3(SO3):
             elif isinstance(x, SO3):
                 self.data = [smb.r2t(_x) for _x in x.data]
             elif isinstance(x, SE2):  # type(x).__name__ == "SE2":
-
-                def convert(x):
-                    # convert SE(2) to SE(3)
-                    out = np.identity(4, dtype=x.dtype)
-                    out[:2, :2] = x[:2, :2]
-                    out[:2, 3] = x[:2, 2]
-                    return out
-
-                self.data = [convert(_x) for _x in x.data]
+                self.data = x.SE3().data
             elif smb.isvector(x, 3):
                 # SE3( [x, y, z] )
                 self.data = [smb.transl(x)]
@@ -1169,6 +1161,9 @@ class SE3(SO3):
             return SE3(smb.trinv(self.A), check=False)
         else:
             return SE3([smb.trinv(x) for x in self.A], check=False)
+
+    def SE2(self) -> SE2:
+        return SE2(self.x, self.y, self.rpy()[2])
 
     def delta(self, X2: Optional[SE3] = None) -> R6:
         r"""

--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -1186,11 +1186,11 @@ class SE3(SO3):
 
         """
         if len(self) == 1:
-            if order in "zyx":
+            if order == "zyx":
                 return SE2(self.x, self.y, self.rpy(order = order)[2])
-            elif order in "xyz":
+            elif order == "xyz":
                 return SE2(self.z, self.y, self.rpy(order = order)[2])
-            elif order in "yxz":
+            elif order == "yxz":
                 return SE2(self.z, self.x, self.rpy(order = order)[2])
         else:
             return SE2([e.yaw_SE2() for e in self])

--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -1169,7 +1169,7 @@ class SE3(SO3):
         :param order: angle sequence order, default to 'zyx'
         :type order: str
         :return: SE(2) with same rotation as the yaw angle using the roll-pitch-yaw convention,
-            and translation in x,y.
+            and translation along the roll-pitch axes.
         :rtype: SE2 instance
 
         Roll-pitch-yaw corresponds to successive rotations about the axes specified by ``order``:
@@ -1186,7 +1186,12 @@ class SE3(SO3):
 
         """
         if len(self) == 1:
-            return SE2(self.x, self.y, self.rpy(order = order)[2])
+            if order in "zyx":
+                return SE2(self.x, self.y, self.rpy(order = order)[2])
+            elif order in "xyz":
+                return SE2(self.z, self.y, self.rpy(order = order)[2])
+            elif order in "yxz":
+                return SE2(self.z, self.x, self.rpy(order = order)[2])
         else:
             return SE2([e.yaw_SE2() for e in self])
 

--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -1163,7 +1163,10 @@ class SE3(SO3):
             return SE3([smb.trinv(x) for x in self.A], check=False)
 
     def SE2(self) -> SE2:
-        return SE2(self.x, self.y, self.rpy()[2])
+        if len(self) == 1:
+            return SE2(self.x, self.y, self.rpy()[2])
+        else:
+            return SE2([e.SE2() for e in self])
 
     def delta(self, X2: Optional[SE3] = None) -> R6:
         r"""

--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -1163,6 +1163,16 @@ class SE3(SO3):
             return SE3([smb.trinv(x) for x in self.A], check=False)
 
     def SE2(self) -> SE2:
+        """
+        Create SE(2) from SE(3)
+
+        :return: SE(2) with same rotation as the yaw angle using the 'zyx' convention,
+            and translation in x,y
+        :rtype: SE2 instance
+
+        "Flattens" 3D rigid-body motion to 2D, along the z axis.
+
+        """
         if len(self) == 1:
             return SE2(self.x, self.y, self.rpy()[2])
         else:

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -663,7 +663,7 @@ class TestSO3(unittest.TestCase):
         # conversion to SE2
         poseSE3 = SE3.Tx(3.3) * SE3.Rz(1.5)
         poseSE2 = poseSE3.yaw_SE2()
-        nt.assert_almost_equal(poseSE3.R[0:1,0:1], poseSE2.R[0:1,0:1])
+        nt.assert_almost_equal(poseSE3.R[0:2,0:2], poseSE2.R[0:2,0:2])
         nt.assert_equal(poseSE3.x , poseSE2.x)
         nt.assert_equal(poseSE3.y , poseSE2.y)
 

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -662,13 +662,13 @@ class TestSO3(unittest.TestCase):
 
         # conversion to SE2
         poseSE3 = SE3.Tx(3.3) * SE3.Rz(1.5)
-        poseSE2 = poseSE3.SE2()
+        poseSE2 = poseSE3.yaw_SE2()
         nt.assert_almost_equal(poseSE3.R[0:1,0:1], poseSE2.R[0:1,0:1])
         nt.assert_equal(poseSE3.x , poseSE2.x)
         nt.assert_equal(poseSE3.y , poseSE2.y)
 
         posesSE3 = SE3([poseSE3, poseSE3])
-        posesSE2 = posesSE3.SE2()
+        posesSE2 = posesSE3.yaw_SE2()
         nt.assert_equal(len(posesSE2), 2)
 
     def test_functions_vect(self):

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -667,6 +667,9 @@ class TestSO3(unittest.TestCase):
         nt.assert_equal(poseSE3.x , poseSE2.x)
         nt.assert_equal(poseSE3.y , poseSE2.y)
 
+        posesSE3 = SE3([poseSE3, poseSE3])
+        posesSE2 = posesSE3.SE2()
+        nt.assert_equal(len(posesSE2), 2)
 
     def test_functions_vect(self):
         # inv

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -659,7 +659,14 @@ class TestSO3(unittest.TestCase):
     def test_functions(self):
         # inv
         # .T
-        pass
+
+        # conversion to SE2
+        poseSE3 = SE3.Tx(3.3) * SE3.Rz(1.5)
+        poseSE2 = poseSE3.SE2()
+        nt.assert_almost_equal(poseSE3.R[0:1,0:1], poseSE2.R[0:1,0:1])
+        nt.assert_equal(poseSE3.x , poseSE2.x)
+        nt.assert_equal(poseSE3.y , poseSE2.y)
+
 
     def test_functions_vect(self):
         # inv


### PR DESCRIPTION
There is functionality to "lift" an SE2 object to an SE3 object. This adds the ability to "flatten" an SE3 object to SE2. It is useful for some of the workflows at BDAI. 

I added a unit test for this. 