### PR TITLE
[SW-237] Raises error if a number of arguments besides 1 and 3 are passed in to SE3 constructors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 "Homepage" = "https://github.com/petercorke/spatialmath-python"
 "Bug Tracker" = "https://github.com/petercorke/spatialmath-python/issues"
 "Documentation" = "https://petercorke.github.io/petercorke/spatialmath-python"
-# "Source" = "https://github.com/petercorke/petercorke/spatialmath-python"
+"Source" = "https://github.com/petercorke/petercorke/spatialmath-python"
 
 [project.optional-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 "Homepage" = "https://github.com/petercorke/spatialmath-python"
 "Bug Tracker" = "https://github.com/petercorke/spatialmath-python/issues"
 "Documentation" = "https://petercorke.github.io/petercorke/spatialmath-python"
-"Source" = "https://github.com/petercorke/petercorke/spatialmath-python"
+# "Source" = "https://github.com/petercorke/petercorke/spatialmath-python"
 
 [project.optional-dependencies]
 

--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -976,6 +976,9 @@ class SE3(SO3):
             # SE3(x, y, z)
             self.data = [smb.transl(x, y, z)]
 
+        else:
+            raise ValueError("Invalid arguments. See documentation for correct format.")
+
     @staticmethod
     def _identity() -> NDArray:
         return np.eye(4)

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -836,7 +836,7 @@ class TestSE3(unittest.TestCase):
         # Bad number of arguments
         with self.assertRaises(ValueError):
             T = SE3(1.0, 0.0)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             T = SE3(1.0, 0.0, 0.0, 0.0)
 
     def test_shape(self):

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -833,6 +833,12 @@ class TestSE3(unittest.TestCase):
         self.assertEqual(T.A.shape, (4,4))
         nt.assert_equal(T.t, [1, 2, 0])
 
+        # Bad number of arguments
+        with self.assertRaises(ValueError):
+            T = SE3(1.0, 0.0)
+        with self.assertRaises(ValueError):
+            T = SE3(1.0, 0.0, 0.0, 0.0)
+
     def test_shape(self):
         a = SE3()
         self.assertEqual(a._A.shape, a.shape)


### PR DESCRIPTION
Decided not to assign default args in the event of something like (x, y) being passed in because default values aren't specified