### PR TITLE
Fixed domain errors in acos near identity

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -1376,7 +1376,9 @@ def trlog(
                 return skew(w * theta)
         else:
             # general case
-            theta = math.acos((np.trace(R) - 1) / 2)
+            tr = (np.trace(R) - 1) / 2
+            # min for inaccuracies near identity yielding trace > 3
+            theta = math.acos(min(tr, 1.0))
             st = math.sin(theta)
             if st == 0:
                 if twist:

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -8,12 +8,14 @@ we will assume that the primitives rotx,trotx, etc. all work
 from math import pi
 from spatialmath import SE3, SO3, SE2
 import numpy as np
+
 # from spatialmath import super_pose as sp
 from spatialmath.base import *
 from spatialmath.base import argcheck
 import spatialmath as sm
 from spatialmath.baseposematrix import BasePoseMatrix
 from spatialmath.twist import BaseTwist
+
 
 def array_compare(x, y):
     if isinstance(x, BasePoseMatrix):
@@ -30,10 +32,9 @@ def array_compare(x, y):
 class TestSO3(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
-        plt.close('all')
+        plt.close("all")
 
     def test_constructor(self):
-
         # null constructor
         R = SO3()
         nt.assert_equal(len(R), 1)
@@ -85,7 +86,6 @@ class TestSO3(unittest.TestCase):
         array_compare(R2, rotx(pi / 2))
 
     def test_constructor_Eul(self):
-
         R = SO3.Eul([0.1, 0.2, 0.3])
         nt.assert_equal(len(R), 1)
         array_compare(R, eul2r([0.1, 0.2, 0.3]))
@@ -101,108 +101,100 @@ class TestSO3(unittest.TestCase):
         array_compare(R, eul2r([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.Eul([10, 20, 30], unit='deg')
+        R = SO3.Eul([10, 20, 30], unit="deg")
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2r([10, 20, 30], unit='deg'))
+        array_compare(R, eul2r([10, 20, 30], unit="deg"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.Eul(10, 20, 30, unit='deg')
+        R = SO3.Eul(10, 20, 30, unit="deg")
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2r([10, 20, 30], unit='deg'))
+        array_compare(R, eul2r([10, 20, 30], unit="deg"))
         self.assertIsInstance(R, SO3)
 
         # matrix input
 
-        angles = np.array([
-            [0.1, 0.2, 0.3],
-            [0.2, 0.3, 0.4],
-            [0.3, 0.4, 0.5],
-            [0.4, 0.5, 0.6]
-        ])
+        angles = np.array(
+            [[0.1, 0.2, 0.3], [0.2, 0.3, 0.4], [0.3, 0.4, 0.5], [0.4, 0.5, 0.6]]
+        )
         R = SO3.Eul(angles)
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], eul2r(angles[i,:]))
+            array_compare(R[i], eul2r(angles[i, :]))
 
         angles *= 10
-        R = SO3.Eul(angles, unit='deg')
+        R = SO3.Eul(angles, unit="deg")
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], eul2r(angles[i,:], unit='deg'))
-
+            array_compare(R[i], eul2r(angles[i, :], unit="deg"))
 
     def test_constructor_RPY(self):
-
-        R = SO3.RPY(0.1, 0.2, 0.3, order='zyx')
+        R = SO3.RPY(0.1, 0.2, 0.3, order="zyx")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(10, 20, 30, unit='deg', order='zyx')
+        R = SO3.RPY(10, 20, 30, unit="deg", order="zyx")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([10, 20, 30], order='zyx', unit='deg'))
+        array_compare(R, rpy2r([10, 20, 30], order="zyx", unit="deg"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY([0.1, 0.2, 0.3], order='zyx')
+        R = SO3.RPY([0.1, 0.2, 0.3], order="zyx")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order='zyx')
+        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order="zyx")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
         self.assertIsInstance(R, SO3)
 
         # check default
         R = SO3.RPY([0.1, 0.2, 0.3])
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
         self.assertIsInstance(R, SO3)
 
         # XYZ order
 
-        R = SO3.RPY(0.1, 0.2, 0.3, order='xyz')
+        R = SO3.RPY(0.1, 0.2, 0.3, order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(10, 20, 30, unit='deg', order='xyz')
+        R = SO3.RPY(10, 20, 30, unit="deg", order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([10, 20, 30], order='xyz', unit='deg'))
+        array_compare(R, rpy2r([10, 20, 30], order="xyz", unit="deg"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY([0.1, 0.2, 0.3], order='xyz')
+        R = SO3.RPY([0.1, 0.2, 0.3], order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order='xyz')
+        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
         self.assertIsInstance(R, SO3)
 
         # matrix input
 
-        angles = np.array([
-            [0.1, 0.2, 0.3],
-            [0.2, 0.3, 0.4],
-            [0.3, 0.4, 0.5],
-            [0.4, 0.5, 0.6]
-        ])
-        R = SO3.RPY(angles, order='zyx')
+        angles = np.array(
+            [[0.1, 0.2, 0.3], [0.2, 0.3, 0.4], [0.3, 0.4, 0.5], [0.4, 0.5, 0.6]]
+        )
+        R = SO3.RPY(angles, order="zyx")
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], rpy2r(angles[i,:], order='zyx'))
+            array_compare(R[i], rpy2r(angles[i, :], order="zyx"))
 
         angles *= 10
-        R = SO3.RPY(angles, unit='deg', order='zyx')
+        R = SO3.RPY(angles, unit="deg", order="zyx")
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], rpy2r(angles[i,:], unit='deg', order='zyx'))
+            array_compare(R[i], rpy2r(angles[i, :], unit="deg", order="zyx"))
 
     def test_constructor_AngVec(self):
         # angvec
@@ -256,16 +248,15 @@ class TestSO3(unittest.TestCase):
 
         s = str(R)
         self.assertIsInstance(s, str)
-        self.assertEqual(s.count('\n'), 3)
+        self.assertEqual(s.count("\n"), 3)
 
         s = repr(R)
         self.assertIsInstance(s, str)
-        self.assertEqual(s.count('\n'), 2)
+        self.assertEqual(s.count("\n"), 2)
 
     def test_printline(self):
-        
-        R = SO3.Rx( 0.3)
-        
+        R = SO3.Rx(0.3)
+
         R.printline()
         # s = R.printline(file=None)
         # self.assertIsInstance(s, str)
@@ -274,17 +265,17 @@ class TestSO3(unittest.TestCase):
         s = R.printline(file=None)
         # self.assertIsInstance(s, str)
         # self.assertEqual(s.count('\n'), 2)
-        
+
     def test_plot(self):
-        plt.close('all')
-        
-        R = SO3.Rx( 0.3)
+        plt.close("all")
+
+        R = SO3.Rx(0.3)
         R.plot(block=False)
-        
+
         R2 = SO3.Rx(0.6)
         # R.animate()
         # R.animate(start=R.inv())
-        
+
     def test_listpowers(self):
         R = SO3()
         R1 = SO3.Rx(0.2)
@@ -314,7 +305,6 @@ class TestSO3(unittest.TestCase):
         array_compare(R[2], rotx(0.3))
 
     def test_tests(self):
-
         R = SO3()
 
         self.assertEqual(R.isrot(), True)
@@ -323,7 +313,6 @@ class TestSO3(unittest.TestCase):
         self.assertEqual(R.ishom2(), False)
 
     def test_properties(self):
-
         R = SO3()
 
         self.assertEqual(R.isSO, True)
@@ -363,8 +352,6 @@ class TestSO3(unittest.TestCase):
         # self.assertNotIsInstance(a, SO3)
         # array_compare(a, np.array([ [2,0,0], [0,2,0], [0,0,2]]))
         #  this invokes the __add__ method for numpy
-
-
 
         # difference
         R = SO3()
@@ -454,26 +441,23 @@ class TestSO3(unittest.TestCase):
 
         # power
 
-        R = SO3.Rx(pi/2)
+        R = SO3.Rx(pi / 2)
         R = R**2
         array_compare(R, SO3.Rx(pi))
 
-        R = SO3.Rx(pi/2)
+        R = SO3.Rx(pi / 2)
         R **= 2
         array_compare(R, SO3.Rx(pi))
 
-        R = SO3.Rx(pi/4)
-        R = R**(-2)
-        array_compare(R, SO3.Rx(-pi/2))
+        R = SO3.Rx(pi / 4)
+        R = R ** (-2)
+        array_compare(R, SO3.Rx(-pi / 2))
 
-        R = SO3.Rx(pi/4)
+        R = SO3.Rx(pi / 4)
         R **= -2
-        array_compare(R, SO3.Rx(-pi/2))
-
-
+        array_compare(R, SO3.Rx(-pi / 2))
 
     def test_arith_vect(self):
-
         rx = SO3.Rx(pi / 2)
         ry = SO3.Ry(pi / 2)
         rz = SO3.Rz(pi / 2)
@@ -655,7 +639,6 @@ class TestSO3(unittest.TestCase):
         array_compare(a[1], ry + 1)
         array_compare(a[2], rz + 1)
 
-
         # subtract
         R = SO3([rx, ry, rz])
         a = R - rx
@@ -679,8 +662,6 @@ class TestSO3(unittest.TestCase):
         array_compare(a[1], ry - ry)
         array_compare(a[2], rz - rz)
 
-
-
     def test_functions(self):
         # inv
         # .T
@@ -688,9 +669,9 @@ class TestSO3(unittest.TestCase):
         # conversion to SE2
         poseSE3 = SE3.Tx(3.3) * SE3.Rz(1.5)
         poseSE2 = poseSE3.yaw_SE2()
-        nt.assert_almost_equal(poseSE3.R[0:2,0:2], poseSE2.R[0:2,0:2])
-        nt.assert_equal(poseSE3.x , poseSE2.x)
-        nt.assert_equal(poseSE3.y , poseSE2.y)
+        nt.assert_almost_equal(poseSE3.R[0:2, 0:2], poseSE2.R[0:2, 0:2])
+        nt.assert_equal(poseSE3.x, poseSE2.x)
+        nt.assert_equal(poseSE3.y, poseSE2.y)
 
         posesSE3 = SE3([poseSE3, poseSE3])
         posesSE2 = posesSE3.yaw_SE2()
@@ -701,16 +682,24 @@ class TestSO3(unittest.TestCase):
         # .T
         pass
 
+    def test_functions_lie(self):
+        R = SO3.EulerVec([0.42, 0.73, -1.17])
+
+        # Check log and exponential map
+        nt.assert_equal(R, SO3.Exp(R.log()))
+        # Check euler vector map
+        nt.assert_equal(R, SO3.EulerVec(R.eulervec()))
+
+
 # ============================== SE3 =====================================#
 
-class TestSE3(unittest.TestCase):
 
+class TestSE3(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
-        plt.close('all')
+        plt.close("all")
 
     def test_constructor(self):
-
         # null constructor
         R = SE3()
         nt.assert_equal(len(R), 1)
@@ -766,9 +755,9 @@ class TestSE3(unittest.TestCase):
         array_compare(R, eul2tr([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.Eul([10, 20, 30], unit='deg')
+        R = SE3.Eul([10, 20, 30], unit="deg")
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2tr([10, 20, 30], unit='deg'))
+        array_compare(R, eul2tr([10, 20, 30], unit="deg"))
         self.assertIsInstance(R, SE3)
 
         R = SE3.RPY([0.1, 0.2, 0.3])
@@ -781,14 +770,14 @@ class TestSE3(unittest.TestCase):
         array_compare(R, rpy2tr([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.RPY([10, 20, 30], unit='deg')
+        R = SE3.RPY([10, 20, 30], unit="deg")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2tr([10, 20, 30], unit='deg'))
+        array_compare(R, rpy2tr([10, 20, 30], unit="deg"))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.RPY([0.1, 0.2, 0.3], order='xyz')
+        R = SE3.RPY([0.1, 0.2, 0.3], order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2tr([0.1, 0.2, 0.3], order='xyz'))
+        array_compare(R, rpy2tr([0.1, 0.2, 0.3], order="xyz"))
         self.assertIsInstance(R, SE3)
 
         # angvec
@@ -819,7 +808,7 @@ class TestSE3(unittest.TestCase):
         t = T.t
         T = SE3.Rt(R, t)
         self.assertIsInstance(T, SE3)
-        self.assertEqual(T.A.shape, (4,4))
+        self.assertEqual(T.A.shape, (4, 4))
 
         nt.assert_equal(T.R, R)
         nt.assert_equal(T.t, t)
@@ -835,9 +824,9 @@ class TestSE3(unittest.TestCase):
         nt.assert_equal(TT.z.shape, desired_shape)
 
         ones = np.ones(desired_shape)
-        nt.assert_equal(TT.x, ones*t[0])
-        nt.assert_equal(TT.y, ones*t[1])
-        nt.assert_equal(TT.z, ones*t[2])
+        nt.assert_equal(TT.x, ones * t[0])
+        nt.assert_equal(TT.y, ones * t[1])
+        nt.assert_equal(TT.z, ones * t[2])
 
         # copy constructor
         R = SE3.Rx(pi / 2)
@@ -855,7 +844,7 @@ class TestSE3(unittest.TestCase):
         T = SE3(SE2(1, 2, 0.4))
         nt.assert_equal(len(T), 1)
         self.assertIsInstance(T, SE3)
-        self.assertEqual(T.A.shape, (4,4))
+        self.assertEqual(T.A.shape, (4, 4))
         nt.assert_equal(T.t, [1, 2, 0])
 
         # Bad number of arguments
@@ -897,7 +886,6 @@ class TestSE3(unittest.TestCase):
         array_compare(R[2], trotx(0.3))
 
     def test_tests(self):
-
         R = SE3()
 
         self.assertEqual(R.isrot(), False)
@@ -906,7 +894,6 @@ class TestSE3(unittest.TestCase):
         self.assertEqual(R.ishom2(), False)
 
     def test_properties(self):
-
         R = SE3()
 
         self.assertEqual(R.isSO, False)
@@ -927,12 +914,8 @@ class TestSE3(unittest.TestCase):
         nt.assert_allclose(pass_by_val.data[0], np.eye(4))
         nt.assert_allclose(pass_by_ref.data[0], mutable_array)
         nt.assert_raises(
-            AssertionError,
-            nt.assert_allclose,
-            pass_by_val.data[0],
-            pass_by_ref.data[0]
-            )
-
+            AssertionError, nt.assert_allclose, pass_by_val.data[0], pass_by_ref.data[0]
+        )
 
     def test_arith(self):
         T = SE3(1, 2, 3)
@@ -940,11 +923,15 @@ class TestSE3(unittest.TestCase):
         # sum
         a = T + T
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[2, 0, 0, 2], [0, 2, 0, 4], [0, 0, 2, 6], [0, 0, 0, 2]]))
+        array_compare(
+            a, np.array([[2, 0, 0, 2], [0, 2, 0, 4], [0, 0, 2, 6], [0, 0, 0, 2]])
+        )
 
         a = T + 1
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[2, 1, 1, 2], [1, 2, 1, 3], [1, 1, 2, 4], [1, 1, 1, 2]]))
+        array_compare(
+            a, np.array([[2, 1, 1, 2], [1, 2, 1, 3], [1, 1, 2, 4], [1, 1, 1, 2]])
+        )
 
         # a = 1 + T
         # self.assertNotIsInstance(a, SE3)
@@ -952,7 +939,9 @@ class TestSE3(unittest.TestCase):
 
         a = T + np.eye(4)
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[2, 0, 0, 1], [0, 2, 0, 2], [0, 0, 2, 3], [0, 0, 0, 2]]))
+        array_compare(
+            a, np.array([[2, 0, 0, 1], [0, 2, 0, 2], [0, 0, 2, 3], [0, 0, 0, 2]])
+        )
 
         # a =  np.eye(3) + T
         # self.assertNotIsInstance(a, SE3)
@@ -968,7 +957,10 @@ class TestSE3(unittest.TestCase):
 
         a = T - 1
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[0, -1, -1, 0], [-1, 0, -1, 1], [-1, -1, 0, 2], [-1, -1, -1, 0]]))
+        array_compare(
+            a,
+            np.array([[0, -1, -1, 0], [-1, 0, -1, 1], [-1, -1, 0, 2], [-1, -1, -1, 0]]),
+        )
 
         # a = 1 - T
         # self.assertNotIsInstance(a, SE3)
@@ -976,7 +968,9 @@ class TestSE3(unittest.TestCase):
 
         a = T - np.eye(4)
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 0, 3], [0, 0, 0, 0]]))
+        array_compare(
+            a, np.array([[0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 0, 3], [0, 0, 0, 0]])
+        )
 
         # a =  np.eye(3) - T
         # self.assertNotIsInstance(a, SE3)
@@ -1005,7 +999,9 @@ class TestSE3(unittest.TestCase):
         T = SE3(1, 2, 3)
         T *= SE3.Ry(pi / 2)
         self.assertIsInstance(T, SE3)
-        array_compare(T, np.array([[0, 0, 1, 1], [0, 1, 0, 2], [-1, 0, 0, 3], [0, 0, 0, 1]]))
+        array_compare(
+            T, np.array([[0, 0, 1, 1], [0, 1, 0, 2], [-1, 0, 0, 3], [0, 0, 0, 1]])
+        )
 
         T = SE3()
         T *= 2
@@ -1048,7 +1044,6 @@ class TestSE3(unittest.TestCase):
         array_compare(a, troty(0.3) / 2)
 
     def test_arith_vect(self):
-
         rx = SE3.Rx(pi / 2)
         ry = SE3.Ry(pi / 2)
         rz = SE3.Rz(pi / 2)
@@ -1260,7 +1255,6 @@ class TestSE3(unittest.TestCase):
         array_compare(a[1], ry - 1)
         array_compare(a[2], rz - 1)
 
-
     def test_functions(self):
         # inv
         # .T
@@ -1271,7 +1265,7 @@ class TestSE3(unittest.TestCase):
         # .T
         pass
 
+
 # ---------------------------------------------------------------------------------------#
-if __name__ == '__main__':
-    
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -8,14 +8,12 @@ we will assume that the primitives rotx,trotx, etc. all work
 from math import pi
 from spatialmath import SE3, SO3, SE2
 import numpy as np
-
 # from spatialmath import super_pose as sp
 from spatialmath.base import *
 from spatialmath.base import argcheck
 import spatialmath as sm
 from spatialmath.baseposematrix import BasePoseMatrix
 from spatialmath.twist import BaseTwist
-
 
 def array_compare(x, y):
     if isinstance(x, BasePoseMatrix):
@@ -32,9 +30,10 @@ def array_compare(x, y):
 class TestSO3(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
-        plt.close("all")
+        plt.close('all')
 
     def test_constructor(self):
+
         # null constructor
         R = SO3()
         nt.assert_equal(len(R), 1)
@@ -86,6 +85,7 @@ class TestSO3(unittest.TestCase):
         array_compare(R2, rotx(pi / 2))
 
     def test_constructor_Eul(self):
+
         R = SO3.Eul([0.1, 0.2, 0.3])
         nt.assert_equal(len(R), 1)
         array_compare(R, eul2r([0.1, 0.2, 0.3]))
@@ -101,100 +101,108 @@ class TestSO3(unittest.TestCase):
         array_compare(R, eul2r([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.Eul([10, 20, 30], unit="deg")
+        R = SO3.Eul([10, 20, 30], unit='deg')
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2r([10, 20, 30], unit="deg"))
+        array_compare(R, eul2r([10, 20, 30], unit='deg'))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.Eul(10, 20, 30, unit="deg")
+        R = SO3.Eul(10, 20, 30, unit='deg')
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2r([10, 20, 30], unit="deg"))
+        array_compare(R, eul2r([10, 20, 30], unit='deg'))
         self.assertIsInstance(R, SO3)
 
         # matrix input
 
-        angles = np.array(
-            [[0.1, 0.2, 0.3], [0.2, 0.3, 0.4], [0.3, 0.4, 0.5], [0.4, 0.5, 0.6]]
-        )
+        angles = np.array([
+            [0.1, 0.2, 0.3],
+            [0.2, 0.3, 0.4],
+            [0.3, 0.4, 0.5],
+            [0.4, 0.5, 0.6]
+        ])
         R = SO3.Eul(angles)
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], eul2r(angles[i, :]))
+            array_compare(R[i], eul2r(angles[i,:]))
 
         angles *= 10
-        R = SO3.Eul(angles, unit="deg")
+        R = SO3.Eul(angles, unit='deg')
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], eul2r(angles[i, :], unit="deg"))
+            array_compare(R[i], eul2r(angles[i,:], unit='deg'))
+
 
     def test_constructor_RPY(self):
-        R = SO3.RPY(0.1, 0.2, 0.3, order="zyx")
+
+        R = SO3.RPY(0.1, 0.2, 0.3, order='zyx')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(10, 20, 30, unit="deg", order="zyx")
+        R = SO3.RPY(10, 20, 30, unit='deg', order='zyx')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([10, 20, 30], order="zyx", unit="deg"))
+        array_compare(R, rpy2r([10, 20, 30], order='zyx', unit='deg'))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY([0.1, 0.2, 0.3], order="zyx")
+        R = SO3.RPY([0.1, 0.2, 0.3], order='zyx')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order="zyx")
+        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order='zyx')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
         self.assertIsInstance(R, SO3)
 
         # check default
         R = SO3.RPY([0.1, 0.2, 0.3])
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
         self.assertIsInstance(R, SO3)
 
         # XYZ order
 
-        R = SO3.RPY(0.1, 0.2, 0.3, order="xyz")
+        R = SO3.RPY(0.1, 0.2, 0.3, order='xyz')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(10, 20, 30, unit="deg", order="xyz")
+        R = SO3.RPY(10, 20, 30, unit='deg', order='xyz')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([10, 20, 30], order="xyz", unit="deg"))
+        array_compare(R, rpy2r([10, 20, 30], order='xyz', unit='deg'))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY([0.1, 0.2, 0.3], order="xyz")
+        R = SO3.RPY([0.1, 0.2, 0.3], order='xyz')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order="xyz")
+        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order='xyz')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
         self.assertIsInstance(R, SO3)
 
         # matrix input
 
-        angles = np.array(
-            [[0.1, 0.2, 0.3], [0.2, 0.3, 0.4], [0.3, 0.4, 0.5], [0.4, 0.5, 0.6]]
-        )
-        R = SO3.RPY(angles, order="zyx")
+        angles = np.array([
+            [0.1, 0.2, 0.3],
+            [0.2, 0.3, 0.4],
+            [0.3, 0.4, 0.5],
+            [0.4, 0.5, 0.6]
+        ])
+        R = SO3.RPY(angles, order='zyx')
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], rpy2r(angles[i, :], order="zyx"))
+            array_compare(R[i], rpy2r(angles[i,:], order='zyx'))
 
         angles *= 10
-        R = SO3.RPY(angles, unit="deg", order="zyx")
+        R = SO3.RPY(angles, unit='deg', order='zyx')
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], rpy2r(angles[i, :], unit="deg", order="zyx"))
+            array_compare(R[i], rpy2r(angles[i,:], unit='deg', order='zyx'))
 
     def test_constructor_AngVec(self):
         # angvec
@@ -248,15 +256,16 @@ class TestSO3(unittest.TestCase):
 
         s = str(R)
         self.assertIsInstance(s, str)
-        self.assertEqual(s.count("\n"), 3)
+        self.assertEqual(s.count('\n'), 3)
 
         s = repr(R)
         self.assertIsInstance(s, str)
-        self.assertEqual(s.count("\n"), 2)
+        self.assertEqual(s.count('\n'), 2)
 
     def test_printline(self):
-        R = SO3.Rx(0.3)
-
+        
+        R = SO3.Rx( 0.3)
+        
         R.printline()
         # s = R.printline(file=None)
         # self.assertIsInstance(s, str)
@@ -265,17 +274,17 @@ class TestSO3(unittest.TestCase):
         s = R.printline(file=None)
         # self.assertIsInstance(s, str)
         # self.assertEqual(s.count('\n'), 2)
-
+        
     def test_plot(self):
-        plt.close("all")
-
-        R = SO3.Rx(0.3)
+        plt.close('all')
+        
+        R = SO3.Rx( 0.3)
         R.plot(block=False)
-
+        
         R2 = SO3.Rx(0.6)
         # R.animate()
         # R.animate(start=R.inv())
-
+        
     def test_listpowers(self):
         R = SO3()
         R1 = SO3.Rx(0.2)
@@ -305,6 +314,7 @@ class TestSO3(unittest.TestCase):
         array_compare(R[2], rotx(0.3))
 
     def test_tests(self):
+
         R = SO3()
 
         self.assertEqual(R.isrot(), True)
@@ -313,6 +323,7 @@ class TestSO3(unittest.TestCase):
         self.assertEqual(R.ishom2(), False)
 
     def test_properties(self):
+
         R = SO3()
 
         self.assertEqual(R.isSO, True)
@@ -352,6 +363,8 @@ class TestSO3(unittest.TestCase):
         # self.assertNotIsInstance(a, SO3)
         # array_compare(a, np.array([ [2,0,0], [0,2,0], [0,0,2]]))
         #  this invokes the __add__ method for numpy
+
+
 
         # difference
         R = SO3()
@@ -441,23 +454,26 @@ class TestSO3(unittest.TestCase):
 
         # power
 
-        R = SO3.Rx(pi / 2)
+        R = SO3.Rx(pi/2)
         R = R**2
         array_compare(R, SO3.Rx(pi))
 
-        R = SO3.Rx(pi / 2)
+        R = SO3.Rx(pi/2)
         R **= 2
         array_compare(R, SO3.Rx(pi))
 
-        R = SO3.Rx(pi / 4)
-        R = R ** (-2)
-        array_compare(R, SO3.Rx(-pi / 2))
+        R = SO3.Rx(pi/4)
+        R = R**(-2)
+        array_compare(R, SO3.Rx(-pi/2))
 
-        R = SO3.Rx(pi / 4)
+        R = SO3.Rx(pi/4)
         R **= -2
-        array_compare(R, SO3.Rx(-pi / 2))
+        array_compare(R, SO3.Rx(-pi/2))
+
+
 
     def test_arith_vect(self):
+
         rx = SO3.Rx(pi / 2)
         ry = SO3.Ry(pi / 2)
         rz = SO3.Rz(pi / 2)
@@ -639,6 +655,7 @@ class TestSO3(unittest.TestCase):
         array_compare(a[1], ry + 1)
         array_compare(a[2], rz + 1)
 
+
         # subtract
         R = SO3([rx, ry, rz])
         a = R - rx
@@ -662,6 +679,8 @@ class TestSO3(unittest.TestCase):
         array_compare(a[1], ry - ry)
         array_compare(a[2], rz - rz)
 
+
+
     def test_functions(self):
         # inv
         # .T
@@ -669,9 +688,9 @@ class TestSO3(unittest.TestCase):
         # conversion to SE2
         poseSE3 = SE3.Tx(3.3) * SE3.Rz(1.5)
         poseSE2 = poseSE3.yaw_SE2()
-        nt.assert_almost_equal(poseSE3.R[0:2, 0:2], poseSE2.R[0:2, 0:2])
-        nt.assert_equal(poseSE3.x, poseSE2.x)
-        nt.assert_equal(poseSE3.y, poseSE2.y)
+        nt.assert_almost_equal(poseSE3.R[0:2,0:2], poseSE2.R[0:2,0:2])
+        nt.assert_equal(poseSE3.x , poseSE2.x)
+        nt.assert_equal(poseSE3.y , poseSE2.y)
 
         posesSE3 = SE3([poseSE3, poseSE3])
         posesSE2 = posesSE3.yaw_SE2()
@@ -696,13 +715,14 @@ class TestSO3(unittest.TestCase):
 
 # ============================== SE3 =====================================#
 
-
 class TestSE3(unittest.TestCase):
+
     @classmethod
     def tearDownClass(cls):
-        plt.close("all")
+        plt.close('all')
 
     def test_constructor(self):
+
         # null constructor
         R = SE3()
         nt.assert_equal(len(R), 1)
@@ -758,9 +778,9 @@ class TestSE3(unittest.TestCase):
         array_compare(R, eul2tr([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.Eul([10, 20, 30], unit="deg")
+        R = SE3.Eul([10, 20, 30], unit='deg')
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2tr([10, 20, 30], unit="deg"))
+        array_compare(R, eul2tr([10, 20, 30], unit='deg'))
         self.assertIsInstance(R, SE3)
 
         R = SE3.RPY([0.1, 0.2, 0.3])
@@ -773,14 +793,14 @@ class TestSE3(unittest.TestCase):
         array_compare(R, rpy2tr([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.RPY([10, 20, 30], unit="deg")
+        R = SE3.RPY([10, 20, 30], unit='deg')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2tr([10, 20, 30], unit="deg"))
+        array_compare(R, rpy2tr([10, 20, 30], unit='deg'))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.RPY([0.1, 0.2, 0.3], order="xyz")
+        R = SE3.RPY([0.1, 0.2, 0.3], order='xyz')
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2tr([0.1, 0.2, 0.3], order="xyz"))
+        array_compare(R, rpy2tr([0.1, 0.2, 0.3], order='xyz'))
         self.assertIsInstance(R, SE3)
 
         # angvec
@@ -811,7 +831,7 @@ class TestSE3(unittest.TestCase):
         t = T.t
         T = SE3.Rt(R, t)
         self.assertIsInstance(T, SE3)
-        self.assertEqual(T.A.shape, (4, 4))
+        self.assertEqual(T.A.shape, (4,4))
 
         nt.assert_equal(T.R, R)
         nt.assert_equal(T.t, t)
@@ -827,9 +847,9 @@ class TestSE3(unittest.TestCase):
         nt.assert_equal(TT.z.shape, desired_shape)
 
         ones = np.ones(desired_shape)
-        nt.assert_equal(TT.x, ones * t[0])
-        nt.assert_equal(TT.y, ones * t[1])
-        nt.assert_equal(TT.z, ones * t[2])
+        nt.assert_equal(TT.x, ones*t[0])
+        nt.assert_equal(TT.y, ones*t[1])
+        nt.assert_equal(TT.z, ones*t[2])
 
         # copy constructor
         R = SE3.Rx(pi / 2)
@@ -847,7 +867,7 @@ class TestSE3(unittest.TestCase):
         T = SE3(SE2(1, 2, 0.4))
         nt.assert_equal(len(T), 1)
         self.assertIsInstance(T, SE3)
-        self.assertEqual(T.A.shape, (4, 4))
+        self.assertEqual(T.A.shape, (4,4))
         nt.assert_equal(T.t, [1, 2, 0])
 
         # Bad number of arguments
@@ -889,6 +909,7 @@ class TestSE3(unittest.TestCase):
         array_compare(R[2], trotx(0.3))
 
     def test_tests(self):
+
         R = SE3()
 
         self.assertEqual(R.isrot(), False)
@@ -897,6 +918,7 @@ class TestSE3(unittest.TestCase):
         self.assertEqual(R.ishom2(), False)
 
     def test_properties(self):
+
         R = SE3()
 
         self.assertEqual(R.isSO, False)
@@ -917,8 +939,12 @@ class TestSE3(unittest.TestCase):
         nt.assert_allclose(pass_by_val.data[0], np.eye(4))
         nt.assert_allclose(pass_by_ref.data[0], mutable_array)
         nt.assert_raises(
-            AssertionError, nt.assert_allclose, pass_by_val.data[0], pass_by_ref.data[0]
-        )
+            AssertionError,
+            nt.assert_allclose,
+            pass_by_val.data[0],
+            pass_by_ref.data[0]
+            )
+
 
     def test_arith(self):
         T = SE3(1, 2, 3)
@@ -926,15 +952,11 @@ class TestSE3(unittest.TestCase):
         # sum
         a = T + T
         self.assertNotIsInstance(a, SE3)
-        array_compare(
-            a, np.array([[2, 0, 0, 2], [0, 2, 0, 4], [0, 0, 2, 6], [0, 0, 0, 2]])
-        )
+        array_compare(a, np.array([[2, 0, 0, 2], [0, 2, 0, 4], [0, 0, 2, 6], [0, 0, 0, 2]]))
 
         a = T + 1
         self.assertNotIsInstance(a, SE3)
-        array_compare(
-            a, np.array([[2, 1, 1, 2], [1, 2, 1, 3], [1, 1, 2, 4], [1, 1, 1, 2]])
-        )
+        array_compare(a, np.array([[2, 1, 1, 2], [1, 2, 1, 3], [1, 1, 2, 4], [1, 1, 1, 2]]))
 
         # a = 1 + T
         # self.assertNotIsInstance(a, SE3)
@@ -942,9 +964,7 @@ class TestSE3(unittest.TestCase):
 
         a = T + np.eye(4)
         self.assertNotIsInstance(a, SE3)
-        array_compare(
-            a, np.array([[2, 0, 0, 1], [0, 2, 0, 2], [0, 0, 2, 3], [0, 0, 0, 2]])
-        )
+        array_compare(a, np.array([[2, 0, 0, 1], [0, 2, 0, 2], [0, 0, 2, 3], [0, 0, 0, 2]]))
 
         # a =  np.eye(3) + T
         # self.assertNotIsInstance(a, SE3)
@@ -960,10 +980,7 @@ class TestSE3(unittest.TestCase):
 
         a = T - 1
         self.assertNotIsInstance(a, SE3)
-        array_compare(
-            a,
-            np.array([[0, -1, -1, 0], [-1, 0, -1, 1], [-1, -1, 0, 2], [-1, -1, -1, 0]]),
-        )
+        array_compare(a, np.array([[0, -1, -1, 0], [-1, 0, -1, 1], [-1, -1, 0, 2], [-1, -1, -1, 0]]))
 
         # a = 1 - T
         # self.assertNotIsInstance(a, SE3)
@@ -971,9 +988,7 @@ class TestSE3(unittest.TestCase):
 
         a = T - np.eye(4)
         self.assertNotIsInstance(a, SE3)
-        array_compare(
-            a, np.array([[0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 0, 3], [0, 0, 0, 0]])
-        )
+        array_compare(a, np.array([[0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 0, 3], [0, 0, 0, 0]]))
 
         # a =  np.eye(3) - T
         # self.assertNotIsInstance(a, SE3)
@@ -1002,9 +1017,7 @@ class TestSE3(unittest.TestCase):
         T = SE3(1, 2, 3)
         T *= SE3.Ry(pi / 2)
         self.assertIsInstance(T, SE3)
-        array_compare(
-            T, np.array([[0, 0, 1, 1], [0, 1, 0, 2], [-1, 0, 0, 3], [0, 0, 0, 1]])
-        )
+        array_compare(T, np.array([[0, 0, 1, 1], [0, 1, 0, 2], [-1, 0, 0, 3], [0, 0, 0, 1]]))
 
         T = SE3()
         T *= 2
@@ -1047,6 +1060,7 @@ class TestSE3(unittest.TestCase):
         array_compare(a, troty(0.3) / 2)
 
     def test_arith_vect(self):
+
         rx = SE3.Rx(pi / 2)
         ry = SE3.Ry(pi / 2)
         rz = SE3.Rz(pi / 2)
@@ -1258,6 +1272,7 @@ class TestSE3(unittest.TestCase):
         array_compare(a[1], ry - 1)
         array_compare(a[2], rz - 1)
 
+
     def test_functions(self):
         # inv
         # .T
@@ -1268,7 +1283,7 @@ class TestSE3(unittest.TestCase):
         # .T
         pass
 
-
 # ---------------------------------------------------------------------------------------#
-if __name__ == "__main__":
+if __name__ == '__main__':
+    
     unittest.main()

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -687,8 +687,11 @@ class TestSO3(unittest.TestCase):
 
         # Check log and exponential map
         nt.assert_equal(R, SO3.Exp(R.log()))
+        np.testing.assert_equal((R.inv() * R).log(), np.zeros([3, 3]))
+
         # Check euler vector map
         nt.assert_equal(R, SO3.EulerVec(R.eulervec()))
+        np.testing.assert_equal((R.inv() * R).eulervec(), np.zeros(3))
 
 
 # ============================== SE3 =====================================#


### PR DESCRIPTION
Found an error when using the log map on near identy rotations. This was cause by slight inaccuracies in the conversion resulting in a trace of 3 + eps, which results in a value > 1 being passed to acos in the log map function. Added a min between the value and 1 to fix this as well as unit tests. 

``
from spatialmath import  SO3
R = SO3.Rand()
R_test = (R.inv() * R)
print((R.inv() * R).eulervec())

``