### PR TITLE
Raise error on invalid rotation matrix in UnitQuaternion constructor.

### DIFF
--- a/spatialmath/quaternion.py
+++ b/spatialmath/quaternion.py
@@ -989,9 +989,12 @@ class UnitQuaternion(Quaternion):
                 #  a quaternion as a 1D array
                 #  an array of quaternions as an nx4 array
 
-                if smb.isrot(s, check=check):
-                    # UnitQuaternion(R) R is 3x3 rotation matrix
-                    self.data = [smb.r2q(s)]
+                if s.shape == (3, 3):
+                    if smb.isrot(s, check=check):
+                        # UnitQuaternion(R) R is 3x3 rotation matrix
+                        self.data = [smb.r2q(s)]
+                    else:
+                        raise ValueError("invalid rotation matrix provided to UnitQuaternion constructor")
                 elif s.shape == (4,):
                     # passed a 4-vector
                     if norm:
@@ -1004,6 +1007,8 @@ class UnitQuaternion(Quaternion):
                     else:
                         # self.data = [smb.qpositive(x) for x in s]
                         self.data = [x for x in s]
+                else:
+                    raise ValueError("array could not be interpreted as UnitQuaternion")
 
             elif isinstance(s, SO3):
                 # UnitQuaternion(x) x is SO3 or SE3 (since SE3 is subclass of SO3)

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -151,6 +151,23 @@ class TestUnitQuaternion(unittest.TestCase):
         q = UnitQuaternion(rotx(0.3))
         qcompare(UnitQuaternion(q), q)
 
+        # fail when invalid arrays are provided
+        # invalid rotation matrix
+        R = 1.1 * np.eye(3)
+        with self.assertRaises(ValueError):
+            UnitQuaternion(R, check=True)
+
+        # no check, so try to interpret as a quaternion, but shape is wrong
+        with self.assertRaises(ValueError):
+            UnitQuaternion(R, check=False)
+
+        # wrong shape to be anything
+        R = np.zeros((5, 5))
+        with self.assertRaises(ValueError):
+            UnitQuaternion(R, check=True)
+        with self.assertRaises(ValueError):
+            UnitQuaternion(R, check=False)
+
     def test_concat(self):
         u = UnitQuaternion()
         uu = UnitQuaternion([u, u, u, u])

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -157,10 +157,6 @@ class TestUnitQuaternion(unittest.TestCase):
         with self.assertRaises(ValueError):
             UnitQuaternion(R, check=True)
 
-        # no check, so try to interpret as a quaternion, but shape is wrong
-        with self.assertRaises(ValueError):
-            UnitQuaternion(R, check=False)
-
         # wrong shape to be anything
         R = np.zeros((5, 5))
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Previously, passing an invalid rotation matrix to the `UnitQuaternion` constructor would just silently fail and yield an identity quaternion. For example:
```python
>>> R = 1.1 * np.eye(3)  # not a valid rotation matrix
>>> UnitQuaternion(R)
1.0000 <<  0.0000,  0.0000,  0.0000 >>
```
Funnily enough, this only happens when `check=True`, since when `check=False` the constructor assumes it can try to interpret the argument as a quaternion (i.e., a vector of length 4) and fails.

This PR fixes this problem by adding additional checks against the argument passed to the constructor, and also has a specific check for when the matrix passed is 3x3 but is not a valid rotation matrix.