### PR TITLE
ensure that angdiff returns a scalar for scalar args

### DIFF
--- a/spatialmath/base/__init__.py
+++ b/spatialmath/base/__init__.py
@@ -216,6 +216,7 @@ __all__ = [
     "isrot2",
     "trlog2",
     "trexp2",
+    "trnorm2",
     "tr2jac2",
     "trinterp2",
     "trprint2",

--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -1533,13 +1533,17 @@ def trexp(S, theta=None, check=True):
         raise ValueError(" First argument must be SO(3), 3-vector, SE(3) or 6-vector")
 
 
+@overload  # pragma: no cover
+def trnorm(R: SO3Array) -> SO3Array:
+    ...
+
+
 def trnorm(T: SE3Array) -> SE3Array:
     r"""
     Normalize an SO(3) or SE(3) matrix
 
-    :param R: SE(3) or SO(3) matrix
-    :type R: ndarray(4,4) or ndarray(3,3)
-    :param T1: second SE(3) matrix
+    :param T: SE(3) or SO(3) matrix
+    :type T: ndarray(4,4) or ndarray(3,3)
     :return: normalized SE(3) or SO(3) matrix
     :rtype: ndarray(4,4) or ndarray(3,3)
     :raises ValueError: bad arguments
@@ -1565,9 +1569,9 @@ def trnorm(T: SE3Array) -> SE3Array:
         >>> T = troty(45, 'deg', t=[3, 4, 5])
         >>> linalg.det(T[:3,:3]) - 1 # is a valid SO(3)
         >>> T = T @ T @ T @ T @ T @ T @ T @ T @ T @ T @ T @ T @ T
-        >>> linalg.det(T[:3,:3]) - 1  # not quite a valid SO(3) anymore
+        >>> linalg.det(T[:3,:3]) - 1  # not quite a valid SE(3) anymore
         >>> T = trnorm(T)
-        >>> linalg.det(T[:3,:3]) - 1  # once more a valid SO(3)
+        >>> linalg.det(T[:3,:3]) - 1  # once more a valid SE(3)
 
     .. note::
 

--- a/spatialmath/base/vectors.py
+++ b/spatialmath/base/vectors.py
@@ -647,7 +647,11 @@ def angdiff(a, b=None):
         b = getvector(b)
         a = a - b  # cannot use -= here, numpy wont broadcast
 
-    return np.mod(a + math.pi, 2 * math.pi) - math.pi
+    y = np.mod(a + math.pi, 2 * math.pi) - math.pi
+    if isinstance(y, np.ndarray) and len(y) == 1:
+        return float(y)
+    else:
+        return y
 
 
 def angle_std(theta: ArrayLike) -> float:

--- a/tests/base/test_transforms2d.py
+++ b/tests/base/test_transforms2d.py
@@ -94,6 +94,20 @@ class Test2D(unittest.TestCase):
         T = transl2(1, 2) @ trot2(0.5)
         nt.assert_array_almost_equal(trexp2(logm(T)), T)
 
+    def test_trnorm2(self):
+        R = rot2(0.4)
+        R = np.round(R, 3)  # approx SO(2)
+        R = trnorm2(R)
+        self.assertTrue(isrot2(R, check=True))
+
+        R = rot2(0.4)
+        R = np.round(R, 3)  # approx SO(2)
+        T = rt2tr(R, [3, 4])
+
+        T = trnorm2(T)
+        self.assertTrue(ishom2(T, check=True))
+        nt.assert_almost_equal(T[:2, 2], [3, 4])
+
     def test_transl2(self):
         nt.assert_array_almost_equal(
             transl2(1, 2), np.array([[1, 0, 1], [0, 1, 2], [0, 0, 1]])

--- a/tests/base/test_transforms3d.py
+++ b/tests/base/test_transforms3d.py
@@ -430,6 +430,20 @@ class Test3D(unittest.TestCase):
         a = rpy2tr(ang, order=seq)
         nt.assert_array_almost_equal(rpy2tr(tr2rpy(a, order=seq), order=seq), a)
 
+    def test_trnorm(self):
+        R = rpy2r(0.2, 0.3, 0.4)
+        R = np.round(R, 3)  # approx SO(3)
+        R = trnorm(R)
+        self.assertTrue(isrot(R, check=True))
+
+        R = rpy2r(0.2, 0.3, 0.4)
+        R = np.round(R, 3)  # approx SO(3)
+        T = rt2tr(R, [3, 4, 5])
+
+        T = trnorm(T)
+        self.assertTrue(ishom(T, check=True))
+        nt.assert_almost_equal(T[:3, 3], [3, 4, 5])
+
     def test_tr2eul(self):
         eul = np.r_[0.1, 0.2, 0.3]
         R = eul2r(eul)

--- a/tests/base/test_vectors.py
+++ b/tests/base/test_vectors.py
@@ -226,16 +226,23 @@ class TestVector(unittest.TestCase):
 
     def test_angdiff(self):
         self.assertEqual(angdiff(0, 0), 0)
+        self.assertIsInstance(angdiff(0, 0), float)
         self.assertEqual(angdiff(pi, 0), -pi)
         self.assertEqual(angdiff(-pi, pi), 0)
 
-        nt.assert_array_almost_equal(angdiff([0, -pi, pi], 0), [0, -pi, -pi])
+        x = angdiff([0, -pi, pi], 0)
+        nt.assert_array_almost_equal(x, [0, -pi, -pi])
+        self.assertIsInstance(x, np.ndarray)
         nt.assert_array_almost_equal(angdiff([0, -pi, pi], pi), [-pi, 0, 0])
 
-        nt.assert_array_almost_equal(angdiff(0, [0, -pi, pi]), [0, -pi, -pi])
+        x = angdiff(0, [0, -pi, pi])
+        nt.assert_array_almost_equal(x, [0, -pi, -pi])
+        self.assertIsInstance(x, np.ndarray)
         nt.assert_array_almost_equal(angdiff(pi, [0, -pi, pi]), [-pi, 0, 0])
 
-        nt.assert_array_almost_equal(angdiff([1, 2, 3], [1, 2, 3]), [0, 0, 0])
+        x = angdiff([1, 2, 3], [1, 2, 3])
+        nt.assert_array_almost_equal(x, [0, 0, 0])
+        self.assertIsInstance(x, np.ndarray)
 
     def test_wrap(self):
         self.assertAlmostEqual(wrap_0_2pi(0), 0)


### PR DESCRIPTION
fix the problem with angdiff, ndarray output for two scalar inputs.  Issue #81.  Also updated the tests.  Note that the equality tests from `unittest` and `numpy.test` consider that a single element array is equal to a scalar.  Now added explicit tests for type of result.