### PR TITLE
Enable black as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+# - repo: https://github.com/charliermarsh/ruff-pre-commit
+#   # Ruff version.
+#   rev: 'v0.1.0'
+#   hooks:
+#     - id: ruff
+#       args: ['--fix', '--config', 'pyproject.toml']
+
+- repo: https://github.com/psf/black
+  rev: 23.10.0
+  hooks:
+    - id: black
+      language_version: python3.10
+      args: ['--config', 'pyproject.toml']
+      verbose: true
+
+# - repo: https://github.com/pre-commit/mirrors-mypy
+#   rev: v1.6.1
+#   hooks:
+#   -   id: mypy

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Install the current code base from GitHub and pip install a link to that cloned 
 git clone https://github.com/bdaiinstitute/spatialmath-python.git
 cd spatialmath-python
 pip install -e .
+# Optional: if you would like to contribute and commit code changes to the repository,
+# pre-commit install
 ```
 
 ## Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "matplotlib",
     "ansitable",
     "typing_extensions",
-    "pre-commit==3.2.2",
+    "pre-commit",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "matplotlib",
     "ansitable",
     "typing_extensions",
+    "pre-commit==3.2.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Enable black as pre-commit hook, update README with a mention of it as an optional setup step.

Early exploration showed that enabling ruff and mypy would be a slightly long term effort, beyond the scope of this task.