### PR TITLE
pass tolerance value when calling sub-routines

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -1329,7 +1329,7 @@ def trlog(
     :seealso: :func:`~trexp` :func:`~spatialmath.base.transformsNd.vex` :func:`~spatialmath.base.transformsNd.vexa`
     """
 
-    if ishom(T, check=check, tol=10):
+    if ishom(T, check=check, tol=tol):
         # SE(3) matrix
 
         [R, t] = tr2rt(T)
@@ -1357,7 +1357,7 @@ def trlog(
             else:
                 return Ab2M(S, v)
 
-    elif isrot(T, check=check):
+    elif isrot(T, check=check, tol=tol):
         # deal with rotation matrix
         R = T
         if abs(np.trace(R) + 1) < tol * _eps:


### PR DESCRIPTION
This PR is part of the effort to improve consistency of tolerance usages in various checks (e.g. `ishom`, `isR`, etc.), it fixes a couple of simple issues where the `tol(erance)` is set but not passed to sub-routines.