### PR TITLE
[SW-562] update unit test skipif condition for mac-related issues

### DIFF
--- a/tests/base/test_graphics.py
+++ b/tests/base/test_graphics.py
@@ -14,19 +14,22 @@ class TestGraphics(unittest.TestCase):
         plt.close("all")
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plotvol2(self):
         plotvol2(5)
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plotvol3(self):
         plotvol3(5)
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot_point(self):
         plot_point((2, 3))
@@ -35,14 +38,16 @@ class TestGraphics(unittest.TestCase):
         plot_point((2, 3), "x", text="foo")
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot_text(self):
         plot_text((2, 3), "foo")
         plot_text(np.r_[2, 3], "foo")
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot_box(self):
         plot_box("r--", centre=(-2, -3), wh=(1, 1))
@@ -54,7 +59,8 @@ class TestGraphics(unittest.TestCase):
         plot_box(centre=(1, 2), wh=(2, 3))
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot_circle(self):
         plot_circle(1, (0, 0), "r")  # red circle
@@ -62,7 +68,8 @@ class TestGraphics(unittest.TestCase):
         plot_circle(0.5, (0, 0), filled=True, color="y")  # yellow filled circle
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_ellipse(self):
         plot_ellipse(np.diag((1, 2)), (0, 0), "r")  # red ellipse
@@ -72,7 +79,8 @@ class TestGraphics(unittest.TestCase):
         )  # yellow filled ellipse
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot_homline(self):
         plot_homline((1, 2, 3))
@@ -80,7 +88,8 @@ class TestGraphics(unittest.TestCase):
         plot_homline((1, -2, 3), "k--")
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_cuboid(self):
         plot_cuboid((1, 2, 3), color="g")
@@ -88,14 +97,16 @@ class TestGraphics(unittest.TestCase):
         plot_cuboid((1, 2, 3), filled=True, color="y")
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_sphere(self):
         plot_sphere(0.3, color="r")
         plot_sphere(1, centre=(1, 1, 1), filled=True, color="b")
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_ellipsoid(self):
         plot_ellipsoid(np.diag((1, 2, 3)), color="r")  # red ellipsoid
@@ -104,7 +115,8 @@ class TestGraphics(unittest.TestCase):
         )  # yellow filled ellipsoid
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_cylinder(self):
         plot_cylinder(radius=0.2, centre=(0.5, 0.5, 0), height=[-0.2, 0.2])
@@ -118,7 +130,8 @@ class TestGraphics(unittest.TestCase):
         )
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_cone(self):
         plot_cone(radius=0.2, centre=(0.5, 0.5, 0), height=0.3)

--- a/tests/base/test_transforms2d.py
+++ b/tests/base/test_transforms2d.py
@@ -262,7 +262,8 @@ class Test2D(unittest.TestCase):
         )
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot(self):
         plt.figure()

--- a/tests/base/test_transforms3d_plot.py
+++ b/tests/base/test_transforms3d_plot.py
@@ -25,7 +25,8 @@ import matplotlib.pyplot as plt
 
 class Test3D(unittest.TestCase):
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot(self):
         plt.figure()
@@ -71,7 +72,8 @@ class Test3D(unittest.TestCase):
         plt.close("all")
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_animate(self):
         tranimate(transl(1, 2, 3), repeat=False, wait=True)

--- a/tests/test_geom2d.py
+++ b/tests/test_geom2d.py
@@ -88,7 +88,8 @@ class Polygon2Test(unittest.TestCase):
         self.assertFalse(p.intersects(l))
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot(self):
         p = Polygon2(np.array([[-1, 1, 1, -1], [-1, -1, 1, 1]]))

--- a/tests/test_geom3d.py
+++ b/tests/test_geom3d.py
@@ -126,7 +126,8 @@ class Line3Test(unittest.TestCase):
         self.assertAlmostEqual(d, 2)
 
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_plot(self):
         P = [2, 3, 7]

--- a/tests/test_pose2d.py
+++ b/tests/test_pose2d.py
@@ -9,12 +9,14 @@ we will assume that the primitives rotx,trotx, etc. all work
 """
 from math import pi
 from spatialmath.pose2d import *
+
 # from spatialmath import super_pose as sp
 from spatialmath.base import *
 import spatialmath.base.argcheck as argcheck
 import spatialmath as sm
 from spatialmath.baseposematrix import BasePoseMatrix
 from spatialmath.twist import BaseTwist
+
 
 def array_compare(x, y):
     if isinstance(x, BasePoseMatrix):
@@ -29,40 +31,35 @@ def array_compare(x, y):
 
 
 class TestSO2(unittest.TestCase):
-
     @classmethod
     def tearDownClass(cls):
-        plt.close('all')
+        plt.close("all")
 
     def test_constructor(self):
-        
-        
         # null case
         x = SO2()
         self.assertIsInstance(x, SO2)
         self.assertEqual(len(x), 1)
-        array_compare(x.A, np.eye(2,2))
-        
+        array_compare(x.A, np.eye(2, 2))
+
         ## from angle
-        
+
         array_compare(SO2(0).A, np.eye(2))
         array_compare(SO2(pi / 2).A, rot2(pi / 2))
-        array_compare(SO2(90, unit='deg').A, rot2(pi / 2))
-       
+        array_compare(SO2(90, unit="deg").A, rot2(pi / 2))
+
         ## from R
-        
-        array_compare(SO2(np.eye(2,2)).A, np.eye(2,2))
-    
-        array_compare(SO2( rot2(pi / 2)).A, rot2(pi / 2))
-        array_compare(SO2( rot2(pi)).A, rot2(pi))
-           
-        
+
+        array_compare(SO2(np.eye(2, 2)).A, np.eye(2, 2))
+
+        array_compare(SO2(rot2(pi / 2)).A, rot2(pi / 2))
+        array_compare(SO2(rot2(pi)).A, rot2(pi))
+
         ## R,T
-        array_compare(SO2( np.eye(2)).R, np.eye(2))
-       
-        array_compare(SO2( rot2(pi / 2)).R, rot2(pi / 2))
-        
-        
+        array_compare(SO2(np.eye(2)).R, np.eye(2))
+
+        array_compare(SO2(rot2(pi / 2)).R, rot2(pi / 2))
+
         ## vectorised forms of R
         R = SO2.Empty()
         for theta in [-pi / 2, 0, pi / 2, pi]:
@@ -72,35 +69,34 @@ class TestSO2(unittest.TestCase):
         array_compare(R[3], rot2(pi))
 
         # TODO self.assertEqual(SO2(R).R, R)
-        
+
         ## copy constructor
         r = SO2(0.3)
         c = SO2(r)
         array_compare(r, c)
         r = SO2(0.4)
         array_compare(c, SO2(0.3))
-    
+
     def test_concat(self):
         x = SO2()
         xx = SO2([x, x, x, x])
-        
+
         self.assertIsInstance(xx, SO2)
         self.assertEqual(len(xx), 4)
-    
+
     def test_primitive_convert(self):
         # char
-        
-        s = str( SO2())
+
+        s = str(SO2())
         self.assertIsInstance(s, str)
-    
+
     def test_shape(self):
         a = SO2()
         self.assertEqual(a._A.shape, a.shape)
 
     def test_constructor_Exp(self):
-
-        array_compare(SO2.Exp( skew(0.3)).R, rot2(0.3))
-        array_compare(SO2.Exp( 0.3).R, rot2(0.3))
+        array_compare(SO2.Exp(skew(0.3)).R, rot2(0.3))
+        array_compare(SO2.Exp(0.3).R, rot2(0.3))
 
         x = SO2.Exp([0, 0.3, 1])
         self.assertEqual(len(x), 3)
@@ -113,113 +109,105 @@ class TestSO2(unittest.TestCase):
         array_compare(x[0], rot2(0))
         array_compare(x[1], rot2(0.3))
         array_compare(x[2], rot2(1))
-    
+
     def test_isa(self):
-        
         self.assertTrue(SO2.isvalid(rot2(0)))
-    
+
         self.assertFalse(SO2.isvalid(1))
-    
+
     def test_resulttype(self):
-        
         r = SO2()
         self.assertIsInstance(r, SO2)
-    
+
         self.assertIsInstance(r * r, SO2)
-        
-    
+
         self.assertIsInstance(r / r, SO2)
-        
+
         self.assertIsInstance(r.inv(), SO2)
-    
-    
+
     def test_multiply(self):
-        
         vx = np.r_[1, 0]
         vy = np.r_[0, 1]
-        
+
         r0 = SO2(0)
         r1 = SO2(pi / 2)
         r2 = SO2(pi)
         u = SO2()
-        
+
         ## SO2-SO2, product
         # scalar x scalar
-        
+
         array_compare(r0 * u, r0)
         array_compare(u * r0, r0)
-        
+
         # vector x vector
-        array_compare(SO2([r0, r1, r2]) * SO2([r2, r0, r1]), SO2([r0 * r2, r1 * r0, r2 * r1]))
-        
+        array_compare(
+            SO2([r0, r1, r2]) * SO2([r2, r0, r1]), SO2([r0 * r2, r1 * r0, r2 * r1])
+        )
+
         # scalar x vector
         array_compare(r1 * SO2([r0, r1, r2]), SO2([r1 * r0, r1 * r1, r1 * r2]))
-        
+
         # vector x scalar
         array_compare(SO2([r0, r1, r2]) * r2, SO2([r0 * r2, r1 * r2, r2 * r2]))
-        
+
         ## SO2-vector product
         # scalar x scalar
-        
+
         array_compare(r1 * vx, np.c_[vy])
-        
+
         # vector x vector
-        #array_compare(SO2([r0, r1, r0]) * np.c_[vy, vx, vx], np.c_[vy, vy, vx])
-        
+        # array_compare(SO2([r0, r1, r0]) * np.c_[vy, vx, vx], np.c_[vy, vy, vx])
+
         # scalar x vector
         array_compare(r1 * np.c_[vx, vy, -vx], np.c_[vy, -vx, -vy])
-        
+
         # vector x scalar
         array_compare(SO2([r0, r1, r2]) * vy, np.c_[vy, -vx, -vy])
 
-    
     def test_divide(self):
-        
         r0 = SO2(0)
         r1 = SO2(pi / 2)
         r2 = SO2(pi)
         u = SO2()
-        
+
         # scalar / scalar
         # implicity tests inv
-    
+
         array_compare(r1 / u, r1)
         array_compare(r1 / r1, u)
-    
+
         # vector / vector
-        array_compare(SO2([r0, r1, r2]) / SO2([r2, r1, r0]), SO2([r0 / r2, r1 / r1, r2 / r0]))
-        
+        array_compare(
+            SO2([r0, r1, r2]) / SO2([r2, r1, r0]), SO2([r0 / r2, r1 / r1, r2 / r0])
+        )
+
         # vector / scalar
         array_compare(SO2([r0, r1, r2]) / r1, SO2([r0 / r1, r1 / r1, r2 / r1]))
-    
-    
+
     def test_conversions(self):
-        
         T = SO2(pi / 2).SE2()
 
         self.assertIsInstance(T, SE2)
-    
-        
+
         ## Lie stuff
         th = 0.3
         RR = SO2(th)
         array_compare(RR.log(), skew(th))
-    
-    
+
     def test_miscellany(self):
-        
-        r = SO2( 0.3,)
+        r = SO2(
+            0.3,
+        )
         self.assertAlmostEqual(np.linalg.det(r.A), 1)
-        
+
         self.assertEqual(r.N, 2)
-        
+
         self.assertFalse(r.isSE)
-    
-    
+
     def test_printline(self):
-        
-        R = SO2( 0.3)
-        
+        R = SO2(0.3)
+
         R.printline()
         # s = R.printline(file=None)
         # self.assertIsInstance(s, str)
@@ -228,87 +216,87 @@ class TestSO2(unittest.TestCase):
         s = R.printline(file=None)
         # self.assertIsInstance(s, str)
         # self.assertEqual(s.count('\n'), 2)
-        
-    @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="tkinter bug with mac")
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
+    )
     def test_plot(self):
-        plt.close('all')
-        
-        R = SO2( 0.3)
+        plt.close("all")
+
+        R = SO2(0.3)
         R.plot(block=False)
-        
+
         R2 = SO2(0.6)
         # R.animate()
         # R.animate(start=R2)
-        
-        
+
+
 # ============================== SE2 =====================================#
 
-class TestSE2(unittest.TestCase):
 
+class TestSE2(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
-        plt.close('all')
+        plt.close("all")
 
     def test_constructor(self):
-        
         self.assertIsInstance(SE2(), SE2)
-    
+
         ## null
-        array_compare(SE2().A, np.eye(3,3))
-        
+        array_compare(SE2().A, np.eye(3, 3))
+
         # from x,y
         x = SE2(2, 3)
         self.assertIsInstance(x, SE2)
         self.assertEqual(len(x), 1)
-        array_compare(x.A, np.array([[1,0,2],[0,1,3],[0,0,1]]))
-        
+        array_compare(x.A, np.array([[1, 0, 2], [0, 1, 3], [0, 0, 1]]))
+
         x = SE2([2, 3])
         self.assertIsInstance(x, SE2)
         self.assertEqual(len(x), 1)
-        array_compare(x.A, np.array([[1,0,2],[0,1,3],[0,0,1]]))
+        array_compare(x.A, np.array([[1, 0, 2], [0, 1, 3], [0, 0, 1]]))
 
         # from x,y,theta
         x = SE2(2, 3, pi / 2)
         self.assertIsInstance(x, SE2)
         self.assertEqual(len(x), 1)
-        array_compare(x.A, np.array([[0,-1,2],[1,0,3],[0,0,1]]))
-        
+        array_compare(x.A, np.array([[0, -1, 2], [1, 0, 3], [0, 0, 1]]))
+
         x = SE2([2, 3, pi / 2])
         self.assertIsInstance(x, SE2)
         self.assertEqual(len(x), 1)
-        array_compare(x.A, np.array([[0,-1,2],[1,0,3],[0,0,1]]))
-        
-        x = SE2(2, 3, 90, unit='deg')
+        array_compare(x.A, np.array([[0, -1, 2], [1, 0, 3], [0, 0, 1]]))
+
+        x = SE2(2, 3, 90, unit="deg")
         self.assertIsInstance(x, SE2)
         self.assertEqual(len(x), 1)
-        array_compare(x.A, np.array([[0,-1,2],[1,0,3],[0,0,1]]))
-        
-        x = SE2([2, 3, 90], unit='deg')
+        array_compare(x.A, np.array([[0, -1, 2], [1, 0, 3], [0, 0, 1]]))
+
+        x = SE2([2, 3, 90], unit="deg")
         self.assertIsInstance(x, SE2)
         self.assertEqual(len(x), 1)
-        array_compare(x.A, np.array([[0,-1,2],[1,0,3],[0,0,1]]))
-    
-        
+        array_compare(x.A, np.array([[0, -1, 2], [1, 0, 3], [0, 0, 1]]))
+
         ## T
         T = transl2(1, 2) @ trot2(0.3)
         x = SE2(T)
         self.assertIsInstance(x, SE2)
         self.assertEqual(len(x), 1)
         array_compare(x.A, T)
-        
-        
+
         ## copy constructor
         TT = SE2(x)
         array_compare(SE2(TT).A, T)
         x = SE2()
         array_compare(SE2(TT).A, T)
-        
+
         ## vectorised versions
-        
-        T1 = transl2(1,2) @ trot2(0.3)
-        T2 = transl2(1,-2) @ trot2(-0.4)
-        
-        x =SE2([T1, T2, T1, T2])
+
+        T1 = transl2(1, 2) @ trot2(0.3)
+        T2 = transl2(1, -2) @ trot2(-0.4)
+
+        x = SE2([T1, T2, T1, T2])
         self.assertIsInstance(x, SE2)
         self.assertEqual(len(x), 4)
         array_compare(x[0], T1)
@@ -321,36 +309,31 @@ class TestSE2(unittest.TestCase):
     def test_concat(self):
         x = SE2()
         xx = SE2([x, x, x, x])
-        
+
         self.assertIsInstance(xx, SE2)
         self.assertEqual(len(xx), 4)
-    
-    
+
     def test_constructor_Exp(self):
+        array_compare(SE2.Exp(skewa([1, 2, 0])), transl2(1, 2))
+        array_compare(SE2.Exp(np.r_[1, 2, 0]), transl2(1, 2))
 
-        array_compare(SE2.Exp(skewa([1,2,0])), transl2(1,2))
-        array_compare(SE2.Exp(np.r_[1,2,0]), transl2(1,2))
-
-        x = SE2.Exp([(1,2,0), (3,4,0), (5,6,0)])
+        x = SE2.Exp([(1, 2, 0), (3, 4, 0), (5, 6, 0)])
         self.assertEqual(len(x), 3)
-        array_compare(x[0], transl2(1,2))
-        array_compare(x[1], transl2(3,4))
-        array_compare(x[2], transl2(5,6))
+        array_compare(x[0], transl2(1, 2))
+        array_compare(x[1], transl2(3, 4))
+        array_compare(x[2], transl2(5, 6))
 
-        x = SE2.Exp([skewa(x) for x in [(1,2,0), (3,4,0), (5,6,0)]])
+        x = SE2.Exp([skewa(x) for x in [(1, 2, 0), (3, 4, 0), (5, 6, 0)]])
         self.assertEqual(len(x), 3)
-        array_compare(x[0], transl2(1,2))
-        array_compare(x[1], transl2(3,4))
-        array_compare(x[2], transl2(5,6))
-    
+        array_compare(x[0], transl2(1, 2))
+        array_compare(x[1], transl2(3, 4))
+        array_compare(x[2], transl2(5, 6))
+
     def test_isa(self):
-        
         self.assertTrue(SE2.isvalid(trot2(0)))
         self.assertFalse(SE2.isvalid(1))
 
-    
     def test_resulttype(self):
-        
         t = SE2()
         self.assertIsInstance(t, SE2)
         self.assertIsInstance(t * t, SE2)
@@ -364,155 +347,144 @@ class TestSE2(unittest.TestCase):
         self.assertIsInstance(2 * t, np.ndarray)
         self.assertIsInstance(t * 2, np.ndarray)
 
-    
-    def test_inverse(self):    
-        
+    def test_inverse(self):
         T1 = transl2(1, 2) @ trot2(0.3)
         TT1 = SE2(T1)
-        
+
         # test inverse
         array_compare(TT1.inv().A, np.linalg.inv(T1))
-        
-        array_compare(TT1 * TT1.inv(),  np.eye(3))
+
+        array_compare(TT1 * TT1.inv(), np.eye(3))
         array_compare(TT1.inv() * TT1, np.eye(3))
-        
+
         # vector case
         TT2 = SE2([TT1, TT1])
         u = [np.eye(3), np.eye(3)]
         array_compare(TT2.inv() * TT1, u)
-    
-    
+
     def test_Rt(self):
-       
-        
         TT1 = SE2.Rand()
         T1 = TT1.A
         R1 = t2r(T1)
         t1 = transl2(T1)
-        
+
         array_compare(TT1.A, T1)
         array_compare(TT1.R, R1)
         array_compare(TT1.t, t1)
         self.assertEqual(TT1.x, t1[0])
         self.assertEqual(TT1.y, t1[1])
-        
+
         TT = SE2([TT1, TT1, TT1])
         array_compare(TT.t, [t1, t1, t1])
-    
-    
+
     def test_arith(self):
-        
-        
         TT1 = SE2.Rand()
         T1 = TT1.A
         TT2 = SE2.Rand()
         T2 = TT2.A
-    
+
         I = SE2()
-        
+
         ## SE2, * SE2, product
         # scalar x scalar
-        
+
         array_compare(TT1 * TT2, T1 @ T2)
         array_compare(TT2 * TT1, T2 @ T1)
         array_compare(TT1 * I, T1)
         array_compare(TT2 * I, TT2)
 
-        
         # vector x vector
-        array_compare(SE2([TT1, TT1, TT2]) * SE2([TT2, TT1, TT1]), SE2([TT1*TT2, TT1*TT1, TT2*TT1]))
-        
+        array_compare(
+            SE2([TT1, TT1, TT2]) * SE2([TT2, TT1, TT1]),
+            SE2([TT1 * TT2, TT1 * TT1, TT2 * TT1]),
+        )
+
         # scalar x vector
-        array_compare(TT1 * SE2([TT2, TT1]), SE2([TT1*TT2, TT1*TT1]))
-        
+        array_compare(TT1 * SE2([TT2, TT1]), SE2([TT1 * TT2, TT1 * TT1]))
+
         # vector x scalar
-        array_compare(SE2([TT1, TT2]) * TT2, SE2([TT1*TT2, TT2*TT2]))
-        
+        array_compare(SE2([TT1, TT2]) * TT2, SE2([TT1 * TT2, TT2 * TT2]))
+
         ## SE2, * vector product
         vx = np.r_[1, 0]
         vy = np.r_[0, 1]
-    
+
         # scalar x scalar
-        
-        array_compare(TT1 * vy, h2e( T1 @ e2h(vy)))
-        
+
+        array_compare(TT1 * vy, h2e(T1 @ e2h(vy)))
+
         # # vector x vector
         # array_compare(SE2([TT1, TT2]) * np.c_[vx, vy], np.c_[h2e(T1 @ e2h(vx)), h2e(T2 @ e2h(vy))])
-        
+
         # scalar x vector
-        array_compare(TT1 * np.c_[vx, vy], h2e( T1 @ e2h(np.c_[vx, vy])))
-        
+        array_compare(TT1 * np.c_[vx, vy], h2e(T1 @ e2h(np.c_[vx, vy])))
+
         # vector x scalar
-        array_compare(SE2([TT1, TT2, TT1]) * vy, np.c_[h2e(T1 @ e2h(vy)), h2e(T2 @ e2h(vy)), h2e(T1 @ e2h(vy))])
-    
+        array_compare(
+            SE2([TT1, TT2, TT1]) * vy,
+            np.c_[h2e(T1 @ e2h(vy)), h2e(T2 @ e2h(vy)), h2e(T1 @ e2h(vy))],
+        )
+
     def test_defs(self):
-        
         # log
         # x = SE2.Exp([2, 3, 0.5])
         # array_compare(x.log(), np.array([[0, -0.5, 2], [0.5, 0, 3], [0, 0, 0]]))
         pass
-    
+
     def test_conversions(self):
-        
-        
         ##  SE2,                     convert to SE2, class
-    
+
         TT = SE2(1, 2, 0.3)
-        
+
         array_compare(TT, transl2(1, 2) @ trot2(0.3))
-        
+
         ## xyt
         array_compare(TT.xyt(), np.r_[1, 2, 0.3])
-        
+
         ## Lie stuff
         x = TT.log()
         self.assertTrue(isskewa(x))
 
-    
     def test_interp(self):
         TT = SE2(2, -4, 0.6)
         I = SE2()
-        
+
         z = I.interp(TT, s=0)
         self.assertIsInstance(z, SE2)
-        
+
         array_compare(I.interp(TT, s=0), I)
         array_compare(I.interp(TT, s=1), TT)
         array_compare(I.interp(TT, s=0.5), SE2(1, -2, 0.3))
-    
+
     def test_miscellany(self):
-        
         TT = SE2(1, 2, 0.3)
-        
-        self.assertEqual(TT.A.shape, (3,3))
-            
+
+        self.assertEqual(TT.A.shape, (3, 3))
+
         self.assertTrue(TT.isSE)
-        
+
         self.assertIsInstance(TT, SE2)
-    
+
     def test_display(self):
-        
         T1 = SE2.Rand()
-        
+
         T1.printline()
-        
+
     @pytest.mark.skipif(
-        sys.platform.startswith("darwin"), reason="tkinter bug with mac"
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
     )
     def test_graphics(self):
-        
-        plt.close('all')
+        plt.close("all")
         T1 = SE2.Rand()
         T2 = SE2.Rand()
-        
 
-        T1.plot(block=False, dims=[-2,2])
-        
-        T1.animate(repeat=False, dims=[-2,2], nframes=10)
-        T1.animate(T0=T2, repeat=False, dims=[-2,2], nframes=10)
+        T1.plot(block=False, dims=[-2, 2])
+
+        T1.animate(repeat=False, dims=[-2, 2], nframes=10)
+        T1.animate(T0=T2, repeat=False, dims=[-2, 2], nframes=10)
 
 
 # ---------------------------------------------------------------------------------------#
-if __name__ == '__main__':
-
+if __name__ == "__main__":
     unittest.main(buffer=True)

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -14,6 +14,7 @@ from spatialmath.base import *
 from spatialmath.baseposematrix import BasePoseMatrix
 from spatialmath.twist import BaseTwist
 
+
 def array_compare(x, y):
     if isinstance(x, BasePoseMatrix):
         x = x.A
@@ -29,10 +30,9 @@ def array_compare(x, y):
 class TestSO3(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
-        plt.close('all')
+        plt.close("all")
 
     def test_constructor(self):
-
         # null constructor
         R = SO3()
         nt.assert_equal(len(R), 1)
@@ -84,7 +84,6 @@ class TestSO3(unittest.TestCase):
         array_compare(R2, rotx(pi / 2))
 
     def test_constructor_Eul(self):
-
         R = SO3.Eul([0.1, 0.2, 0.3])
         nt.assert_equal(len(R), 1)
         array_compare(R, eul2r([0.1, 0.2, 0.3]))
@@ -100,108 +99,100 @@ class TestSO3(unittest.TestCase):
         array_compare(R, eul2r([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.Eul([10, 20, 30], unit='deg')
+        R = SO3.Eul([10, 20, 30], unit="deg")
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2r([10, 20, 30], unit='deg'))
+        array_compare(R, eul2r([10, 20, 30], unit="deg"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.Eul(10, 20, 30, unit='deg')
+        R = SO3.Eul(10, 20, 30, unit="deg")
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2r([10, 20, 30], unit='deg'))
+        array_compare(R, eul2r([10, 20, 30], unit="deg"))
         self.assertIsInstance(R, SO3)
 
         # matrix input
 
-        angles = np.array([
-            [0.1, 0.2, 0.3],
-            [0.2, 0.3, 0.4],
-            [0.3, 0.4, 0.5],
-            [0.4, 0.5, 0.6]
-        ])
+        angles = np.array(
+            [[0.1, 0.2, 0.3], [0.2, 0.3, 0.4], [0.3, 0.4, 0.5], [0.4, 0.5, 0.6]]
+        )
         R = SO3.Eul(angles)
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], eul2r(angles[i,:]))
+            array_compare(R[i], eul2r(angles[i, :]))
 
         angles *= 10
-        R = SO3.Eul(angles, unit='deg')
+        R = SO3.Eul(angles, unit="deg")
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], eul2r(angles[i,:], unit='deg'))
-
+            array_compare(R[i], eul2r(angles[i, :], unit="deg"))
 
     def test_constructor_RPY(self):
-
-        R = SO3.RPY(0.1, 0.2, 0.3, order='zyx')
+        R = SO3.RPY(0.1, 0.2, 0.3, order="zyx")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(10, 20, 30, unit='deg', order='zyx')
+        R = SO3.RPY(10, 20, 30, unit="deg", order="zyx")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([10, 20, 30], order='zyx', unit='deg'))
+        array_compare(R, rpy2r([10, 20, 30], order="zyx", unit="deg"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY([0.1, 0.2, 0.3], order='zyx')
+        R = SO3.RPY([0.1, 0.2, 0.3], order="zyx")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order='zyx')
+        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order="zyx")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
         self.assertIsInstance(R, SO3)
 
         # check default
         R = SO3.RPY([0.1, 0.2, 0.3])
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='zyx'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="zyx"))
         self.assertIsInstance(R, SO3)
 
         # XYZ order
 
-        R = SO3.RPY(0.1, 0.2, 0.3, order='xyz')
+        R = SO3.RPY(0.1, 0.2, 0.3, order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(10, 20, 30, unit='deg', order='xyz')
+        R = SO3.RPY(10, 20, 30, unit="deg", order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([10, 20, 30], order='xyz', unit='deg'))
+        array_compare(R, rpy2r([10, 20, 30], order="xyz", unit="deg"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY([0.1, 0.2, 0.3], order='xyz')
+        R = SO3.RPY([0.1, 0.2, 0.3], order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
         self.assertIsInstance(R, SO3)
 
-        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order='xyz')
+        R = SO3.RPY(np.r_[0.1, 0.2, 0.3], order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2r([0.1, 0.2, 0.3], order='xyz'))
+        array_compare(R, rpy2r([0.1, 0.2, 0.3], order="xyz"))
         self.assertIsInstance(R, SO3)
 
         # matrix input
 
-        angles = np.array([
-            [0.1, 0.2, 0.3],
-            [0.2, 0.3, 0.4],
-            [0.3, 0.4, 0.5],
-            [0.4, 0.5, 0.6]
-        ])
-        R = SO3.RPY(angles, order='zyx')
+        angles = np.array(
+            [[0.1, 0.2, 0.3], [0.2, 0.3, 0.4], [0.3, 0.4, 0.5], [0.4, 0.5, 0.6]]
+        )
+        R = SO3.RPY(angles, order="zyx")
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], rpy2r(angles[i,:], order='zyx'))
+            array_compare(R[i], rpy2r(angles[i, :], order="zyx"))
 
         angles *= 10
-        R = SO3.RPY(angles, unit='deg', order='zyx')
+        R = SO3.RPY(angles, unit="deg", order="zyx")
         self.assertIsInstance(R, SO3)
         nt.assert_equal(len(R), 4)
         for i in range(4):
-            array_compare(R[i], rpy2r(angles[i,:], unit='deg', order='zyx'))
+            array_compare(R[i], rpy2r(angles[i, :], unit="deg", order="zyx"))
 
     def test_constructor_AngVec(self):
         # angvec
@@ -255,16 +246,15 @@ class TestSO3(unittest.TestCase):
 
         s = str(R)
         self.assertIsInstance(s, str)
-        self.assertEqual(s.count('\n'), 3)
+        self.assertEqual(s.count("\n"), 3)
 
         s = repr(R)
         self.assertIsInstance(s, str)
-        self.assertEqual(s.count('\n'), 2)
+        self.assertEqual(s.count("\n"), 2)
 
     def test_printline(self):
-        
-        R = SO3.Rx( 0.3)
-        
+        R = SO3.Rx(0.3)
+
         R.printline()
         # s = R.printline(file=None)
         # self.assertIsInstance(s, str)
@@ -274,17 +264,20 @@ class TestSO3(unittest.TestCase):
         # self.assertIsInstance(s, str)
         # self.assertEqual(s.count('\n'), 2)
 
-    @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="tkinter bug with mac")
+    @pytest.mark.skipif(
+        sys.platform.startswith("darwin") and sys.version_info < (3, 11),
+        reason="tkinter bug with mac",
+    )
     def test_plot(self):
-        plt.close('all')
-        
-        R = SO3.Rx( 0.3)
+        plt.close("all")
+
+        R = SO3.Rx(0.3)
         R.plot(block=False)
-        
+
         R2 = SO3.Rx(0.6)
         # R.animate()
         # R.animate(start=R.inv())
-        
+
     def test_listpowers(self):
         R = SO3()
         R1 = SO3.Rx(0.2)
@@ -314,7 +307,6 @@ class TestSO3(unittest.TestCase):
         array_compare(R[2], rotx(0.3))
 
     def test_tests(self):
-
         R = SO3()
 
         self.assertEqual(R.isrot(), True)
@@ -323,7 +315,6 @@ class TestSO3(unittest.TestCase):
         self.assertEqual(R.ishom2(), False)
 
     def test_properties(self):
-
         R = SO3()
 
         self.assertEqual(R.isSO, True)
@@ -363,8 +354,6 @@ class TestSO3(unittest.TestCase):
         # self.assertNotIsInstance(a, SO3)
         # array_compare(a, np.array([ [2,0,0], [0,2,0], [0,0,2]]))
         #  this invokes the __add__ method for numpy
-
-
 
         # difference
         R = SO3()
@@ -454,26 +443,23 @@ class TestSO3(unittest.TestCase):
 
         # power
 
-        R = SO3.Rx(pi/2)
+        R = SO3.Rx(pi / 2)
         R = R**2
         array_compare(R, SO3.Rx(pi))
 
-        R = SO3.Rx(pi/2)
+        R = SO3.Rx(pi / 2)
         R **= 2
         array_compare(R, SO3.Rx(pi))
 
-        R = SO3.Rx(pi/4)
-        R = R**(-2)
-        array_compare(R, SO3.Rx(-pi/2))
+        R = SO3.Rx(pi / 4)
+        R = R ** (-2)
+        array_compare(R, SO3.Rx(-pi / 2))
 
-        R = SO3.Rx(pi/4)
+        R = SO3.Rx(pi / 4)
         R **= -2
-        array_compare(R, SO3.Rx(-pi/2))
-
-
+        array_compare(R, SO3.Rx(-pi / 2))
 
     def test_arith_vect(self):
-
         rx = SO3.Rx(pi / 2)
         ry = SO3.Ry(pi / 2)
         rz = SO3.Rz(pi / 2)
@@ -655,7 +641,6 @@ class TestSO3(unittest.TestCase):
         array_compare(a[1], ry + 1)
         array_compare(a[2], rz + 1)
 
-
         # subtract
         R = SO3([rx, ry, rz])
         a = R - rx
@@ -679,8 +664,6 @@ class TestSO3(unittest.TestCase):
         array_compare(a[1], ry - ry)
         array_compare(a[2], rz - rz)
 
-
-
     def test_functions(self):
         # inv
         # .T
@@ -688,9 +671,9 @@ class TestSO3(unittest.TestCase):
         # conversion to SE2
         poseSE3 = SE3.Tx(3.3) * SE3.Rz(1.5)
         poseSE2 = poseSE3.yaw_SE2()
-        nt.assert_almost_equal(poseSE3.R[0:2,0:2], poseSE2.R[0:2,0:2])
-        nt.assert_equal(poseSE3.x , poseSE2.x)
-        nt.assert_equal(poseSE3.y , poseSE2.y)
+        nt.assert_almost_equal(poseSE3.R[0:2, 0:2], poseSE2.R[0:2, 0:2])
+        nt.assert_equal(poseSE3.x, poseSE2.x)
+        nt.assert_equal(poseSE3.y, poseSE2.y)
 
         posesSE3 = SE3([poseSE3, poseSE3])
         posesSE2 = posesSE3.yaw_SE2()
@@ -715,14 +698,13 @@ class TestSO3(unittest.TestCase):
 
 # ============================== SE3 =====================================#
 
-class TestSE3(unittest.TestCase):
 
+class TestSE3(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
-        plt.close('all')
+        plt.close("all")
 
     def test_constructor(self):
-
         # null constructor
         R = SE3()
         nt.assert_equal(len(R), 1)
@@ -778,9 +760,9 @@ class TestSE3(unittest.TestCase):
         array_compare(R, eul2tr([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.Eul([10, 20, 30], unit='deg')
+        R = SE3.Eul([10, 20, 30], unit="deg")
         nt.assert_equal(len(R), 1)
-        array_compare(R, eul2tr([10, 20, 30], unit='deg'))
+        array_compare(R, eul2tr([10, 20, 30], unit="deg"))
         self.assertIsInstance(R, SE3)
 
         R = SE3.RPY([0.1, 0.2, 0.3])
@@ -793,14 +775,14 @@ class TestSE3(unittest.TestCase):
         array_compare(R, rpy2tr([0.1, 0.2, 0.3]))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.RPY([10, 20, 30], unit='deg')
+        R = SE3.RPY([10, 20, 30], unit="deg")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2tr([10, 20, 30], unit='deg'))
+        array_compare(R, rpy2tr([10, 20, 30], unit="deg"))
         self.assertIsInstance(R, SE3)
 
-        R = SE3.RPY([0.1, 0.2, 0.3], order='xyz')
+        R = SE3.RPY([0.1, 0.2, 0.3], order="xyz")
         nt.assert_equal(len(R), 1)
-        array_compare(R, rpy2tr([0.1, 0.2, 0.3], order='xyz'))
+        array_compare(R, rpy2tr([0.1, 0.2, 0.3], order="xyz"))
         self.assertIsInstance(R, SE3)
 
         # angvec
@@ -831,7 +813,7 @@ class TestSE3(unittest.TestCase):
         t = T.t
         T = SE3.Rt(R, t)
         self.assertIsInstance(T, SE3)
-        self.assertEqual(T.A.shape, (4,4))
+        self.assertEqual(T.A.shape, (4, 4))
 
         nt.assert_equal(T.R, R)
         nt.assert_equal(T.t, t)
@@ -847,9 +829,9 @@ class TestSE3(unittest.TestCase):
         nt.assert_equal(TT.z.shape, desired_shape)
 
         ones = np.ones(desired_shape)
-        nt.assert_equal(TT.x, ones*t[0])
-        nt.assert_equal(TT.y, ones*t[1])
-        nt.assert_equal(TT.z, ones*t[2])
+        nt.assert_equal(TT.x, ones * t[0])
+        nt.assert_equal(TT.y, ones * t[1])
+        nt.assert_equal(TT.z, ones * t[2])
 
         # copy constructor
         R = SE3.Rx(pi / 2)
@@ -867,7 +849,7 @@ class TestSE3(unittest.TestCase):
         T = SE3(SE2(1, 2, 0.4))
         nt.assert_equal(len(T), 1)
         self.assertIsInstance(T, SE3)
-        self.assertEqual(T.A.shape, (4,4))
+        self.assertEqual(T.A.shape, (4, 4))
         nt.assert_equal(T.t, [1, 2, 0])
 
         # Bad number of arguments
@@ -909,7 +891,6 @@ class TestSE3(unittest.TestCase):
         array_compare(R[2], trotx(0.3))
 
     def test_tests(self):
-
         R = SE3()
 
         self.assertEqual(R.isrot(), False)
@@ -918,7 +899,6 @@ class TestSE3(unittest.TestCase):
         self.assertEqual(R.ishom2(), False)
 
     def test_properties(self):
-
         R = SE3()
 
         self.assertEqual(R.isSO, False)
@@ -939,12 +919,8 @@ class TestSE3(unittest.TestCase):
         nt.assert_allclose(pass_by_val.data[0], np.eye(4))
         nt.assert_allclose(pass_by_ref.data[0], mutable_array)
         nt.assert_raises(
-            AssertionError,
-            nt.assert_allclose,
-            pass_by_val.data[0],
-            pass_by_ref.data[0]
-            )
-
+            AssertionError, nt.assert_allclose, pass_by_val.data[0], pass_by_ref.data[0]
+        )
 
     def test_arith(self):
         T = SE3(1, 2, 3)
@@ -952,11 +928,15 @@ class TestSE3(unittest.TestCase):
         # sum
         a = T + T
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[2, 0, 0, 2], [0, 2, 0, 4], [0, 0, 2, 6], [0, 0, 0, 2]]))
+        array_compare(
+            a, np.array([[2, 0, 0, 2], [0, 2, 0, 4], [0, 0, 2, 6], [0, 0, 0, 2]])
+        )
 
         a = T + 1
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[2, 1, 1, 2], [1, 2, 1, 3], [1, 1, 2, 4], [1, 1, 1, 2]]))
+        array_compare(
+            a, np.array([[2, 1, 1, 2], [1, 2, 1, 3], [1, 1, 2, 4], [1, 1, 1, 2]])
+        )
 
         # a = 1 + T
         # self.assertNotIsInstance(a, SE3)
@@ -964,7 +944,9 @@ class TestSE3(unittest.TestCase):
 
         a = T + np.eye(4)
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[2, 0, 0, 1], [0, 2, 0, 2], [0, 0, 2, 3], [0, 0, 0, 2]]))
+        array_compare(
+            a, np.array([[2, 0, 0, 1], [0, 2, 0, 2], [0, 0, 2, 3], [0, 0, 0, 2]])
+        )
 
         # a =  np.eye(3) + T
         # self.assertNotIsInstance(a, SE3)
@@ -980,7 +962,10 @@ class TestSE3(unittest.TestCase):
 
         a = T - 1
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[0, -1, -1, 0], [-1, 0, -1, 1], [-1, -1, 0, 2], [-1, -1, -1, 0]]))
+        array_compare(
+            a,
+            np.array([[0, -1, -1, 0], [-1, 0, -1, 1], [-1, -1, 0, 2], [-1, -1, -1, 0]]),
+        )
 
         # a = 1 - T
         # self.assertNotIsInstance(a, SE3)
@@ -988,7 +973,9 @@ class TestSE3(unittest.TestCase):
 
         a = T - np.eye(4)
         self.assertNotIsInstance(a, SE3)
-        array_compare(a, np.array([[0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 0, 3], [0, 0, 0, 0]]))
+        array_compare(
+            a, np.array([[0, 0, 0, 1], [0, 0, 0, 2], [0, 0, 0, 3], [0, 0, 0, 0]])
+        )
 
         # a =  np.eye(3) - T
         # self.assertNotIsInstance(a, SE3)
@@ -1017,7 +1004,9 @@ class TestSE3(unittest.TestCase):
         T = SE3(1, 2, 3)
         T *= SE3.Ry(pi / 2)
         self.assertIsInstance(T, SE3)
-        array_compare(T, np.array([[0, 0, 1, 1], [0, 1, 0, 2], [-1, 0, 0, 3], [0, 0, 0, 1]]))
+        array_compare(
+            T, np.array([[0, 0, 1, 1], [0, 1, 0, 2], [-1, 0, 0, 3], [0, 0, 0, 1]])
+        )
 
         T = SE3()
         T *= 2
@@ -1060,7 +1049,6 @@ class TestSE3(unittest.TestCase):
         array_compare(a, troty(0.3) / 2)
 
     def test_arith_vect(self):
-
         rx = SE3.Rx(pi / 2)
         ry = SE3.Ry(pi / 2)
         rz = SE3.Rz(pi / 2)
@@ -1272,7 +1260,6 @@ class TestSE3(unittest.TestCase):
         array_compare(a[1], ry - 1)
         array_compare(a[2], rz - 1)
 
-
     def test_functions(self):
         # inv
         # .T
@@ -1283,7 +1270,7 @@ class TestSE3(unittest.TestCase):
         # .T
         pass
 
+
 # ---------------------------------------------------------------------------------------#
-if __name__ == '__main__':
-    
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Update several unit tests' `skipif` conditions, as a follow-up to https://github.com/bdaiinstitute/spatialmath-python/pull/96
- background: tkinter issue on mac https://github.com/actions/setup-python/issues/649

Some example traces taken from the build-test workflow for this PR:
- [(mac-latestos, 3.11)](https://github.com/bdaiinstitute/spatialmath-python/actions/runs/6935373975/job/18865396757?pr=102): `tests/base/test_graphics.py .............`
- [(mac-latestos, 3.7)](https://github.com/bdaiinstitute/spatialmath-python/actions/runs/6935373975/job/18865395394?pr=102): `tests/base/test_graphics.py sssssssssssss`