### PR TITLE
Update pyproject.toml version based on pypi release history

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spatialmath-python"
-version = "1.1.6"
+version = "1.1.9"
 authors = [
   { name="Peter Corke", email="rvc@petercorke.com" },
 ]


### PR DESCRIPTION
According to https://pypi.org/project/spatialmath-python/#history, the new release version should be > 1.1.8.
