### PR TITLE
Fixed fall through error in binary operation

### DIFF
--- a/spatialmath/baseposematrix.py
+++ b/spatialmath/baseposematrix.py
@@ -1657,7 +1657,7 @@ class BasePoseMatrix(BasePoseList):
         =========   ==========   ====  ================================
 
         """
-        if isinstance(right, left.__class__):
+        if right.__class__ is left.__class__:
             # class by class
             if len(left) == 1:
                 if len(right) == 1:
@@ -1684,7 +1684,10 @@ class BasePoseMatrix(BasePoseList):
             else:
                 return [op(x, right) for x in left.A]
         else:
-            raise ValueError(f'Invalid type ({right.__class__}) for binary operation with {left.__class__}')
+            raise TypeError(
+                f"Invalid type ({right.__class__}) for binary operation with {left.__class__}"
+            )
+
 
 if __name__ == "__main__":
     from spatialmath import SE3, SE2, SO2

--- a/spatialmath/baseposematrix.py
+++ b/spatialmath/baseposematrix.py
@@ -1683,7 +1683,8 @@ class BasePoseMatrix(BasePoseList):
                 return op(left.A, right)
             else:
                 return [op(x, right) for x in left.A]
-
+        else:
+            raise ValueError(f'Invalid type ({right.__class__}) for binary operation with {left.__class__}')
 
 if __name__ == "__main__":
     from spatialmath import SE3, SE2, SO2

--- a/spatialmath/baseposematrix.py
+++ b/spatialmath/baseposematrix.py
@@ -1657,7 +1657,7 @@ class BasePoseMatrix(BasePoseList):
         =========   ==========   ====  ================================
 
         """
-        if right.__class__ is left.__class__:
+        if isinstance(right, left.__class__) or isinstance(left, right.__class__):
             # class by class
             if len(left) == 1:
                 if len(right) == 1:

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -1285,9 +1285,16 @@ class TestSE3(unittest.TestCase):
                 p1a.angdist(other=p2a, metric=metric),
                 p1a.angdist(other=p2b, metric=metric),
             )
-        # angle between mismatched types
-        with self.assertRaises(ValueError):
+        # not allowing angdist between mismatched types
+        with self.assertRaises(TypeError):
             _ = r1.angdist(p1a)
+
+        # in general, the _op2 interface allows same type only
+        with self.assertRaises(TypeError):
+            _ = r1._op2(right=p1a, op=r1.angdist)
+
+        with self.assertRaises(TypeError):
+            _ = p1a._op2(right=r1, op=p1a.angdist)
 
     def test_functions(self):
         # inv

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -1286,14 +1286,14 @@ class TestSE3(unittest.TestCase):
                 p1a.angdist(other=p2b, metric=metric),
             )
         # not allowing angdist between mismatched types
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             _ = r1.angdist(p1a)
 
         # in general, the _op2 interface allows same type only
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             _ = r1._op2(right=p1a, op=r1.angdist)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             _ = p1a._op2(right=r1, op=p1a.angdist)
 
     def test_functions(self):

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -1285,16 +1285,19 @@ class TestSE3(unittest.TestCase):
                 p1a.angdist(other=p2a, metric=metric),
                 p1a.angdist(other=p2b, metric=metric),
             )
-        # not allowing angdist between mismatched types
+        # angdist is not implemented for mismatched types
         with self.assertRaises(ValueError):
             _ = r1.angdist(p1a)
 
-        # in general, the _op2 interface allows same type only
         with self.assertRaises(ValueError):
             _ = r1._op2(right=p1a, op=r1.angdist)
 
         with self.assertRaises(ValueError):
             _ = p1a._op2(right=r1, op=p1a.angdist)
+
+        # in general, the _op2 interface enforces an isinstance check.
+        with self.assertRaises(TypeError):
+            _ = r1._op2(right=(1, 0, 0), op=r1.angdist)
 
     def test_functions(self):
         # inv

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -1260,6 +1260,35 @@ class TestSE3(unittest.TestCase):
         array_compare(a[1], ry - 1)
         array_compare(a[2], rz - 1)
 
+    def test_angle(self):
+        # angle between SO3's
+        r1 = SO3.Rx(0.1)
+        r2 = SO3.Rx(0.2)
+        for metric in range(6):
+            self.assertAlmostEqual(r1.angdist(other=r1, metric=metric), 0.0)
+            self.assertGreater(r1.angdist(other=r2, metric=metric), 0.0)
+            self.assertAlmostEqual(
+                r1.angdist(other=r2, metric=metric), r2.angdist(other=r1, metric=metric)
+            )
+        # angle between SE3's
+        p1a, p1b = SE3.Rx(0.1), SE3.Rx(0.1, t=(1, 2, 3))
+        p2a, p2b = SE3.Rx(0.2), SE3.Rx(0.2, t=(3, 2, 1))
+        for metric in range(6):
+            self.assertAlmostEqual(p1a.angdist(other=p1a, metric=metric), 0.0)
+            self.assertGreater(p1a.angdist(other=p2a, metric=metric), 0.0)
+            self.assertAlmostEqual(p1a.angdist(other=p1b, metric=metric), 0.0)
+            self.assertAlmostEqual(
+                p1a.angdist(other=p2a, metric=metric),
+                p2a.angdist(other=p1a, metric=metric),
+            )
+            self.assertAlmostEqual(
+                p1a.angdist(other=p2a, metric=metric),
+                p1a.angdist(other=p2b, metric=metric),
+            )
+        # angle between mismatched types
+        with self.assertRaises(ValueError):
+            _ = r1.angdist(p1a)
+
     def test_functions(self):
         # inv
         # .T


### PR DESCRIPTION
Fixes fall through error in the binary operator for BasePoseMatrix described in #116:

https://github.com/bdaiinstitute/spatialmath-python/blob/1b89c49395a21b5241e2f0a233e69394f3bc27b1/spatialmath/baseposematrix.py#L1632C7-L1632C7

If you want to compare the rotation of an SE3 to an SO3, it returns `None` as opposed to throwing an error or returning a valid value.

```
import numpy as np
from spatialmath import SE3, SO3

T0 = SE3()
print(T0.angdist(SO3()))
```

Modified `BasePoseMatrix._op2` to throw an error if the types don't match. 

All tests still pass.