### PR TITLE
Bump up setup-python version to v5

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
When testing PR-123, we found that the setup-python@v2 had stopped working correctly for macos-latest configurations. 