### PR TITLE
Fixes several issues that broke the testing workflow

### DIFF
--- a/spatialmath/base/graphics.py
+++ b/spatialmath/base/graphics.py
@@ -1394,9 +1394,9 @@ try:
             edges = [[0, 1, 3, 2, 0], [4, 5, 7, 6, 4], [0, 4], [1, 5], [3, 7], [2, 6]]
             lines = []
             for edge in edges:
-                E = vertices[:, edge]
-                # ax.plot(E[0], E[1], E[2], **kwargs)
-                lines.append(E.T)
+                for line in zip(edge[:-1], edge[1:]):
+                    E = vertices[:, line]
+                    lines.append(E.T)
             if "color" in kwargs:
                 if "alpha" in kwargs:
                     alpha = kwargs["alpha"]

--- a/tests/base/test_symbolic.py
+++ b/tests/base/test_symbolic.py
@@ -58,26 +58,26 @@ class Test_symbolic(unittest.TestCase):
         self.assertTrue(isinstance(sqrt(1.0), float))
 
         x = (theta - 1) * (theta + 1) - theta ** 2
-        self.assertEqual(simplify(x).evalf(), -1)
+        self.assertTrue(math.isclose(simplify(x).evalf(), -1))
 
     @unittest.skipUnless(_symbolics, "sympy required")
     def test_constants(self):
 
         x = zero()
         self.assertTrue(isinstance(x, sp.Expr))
-        self.assertEqual(x.evalf(), 0)
+        self.assertTrue(math.isclose(x.evalf(), 0))
 
         x = one()
         self.assertTrue(isinstance(x, sp.Expr))
-        self.assertEqual(x.evalf(), 1)
+        self.assertTrue(math.isclose(x.evalf(), 1))
 
         x = negative_one()
         self.assertTrue(isinstance(x, sp.Expr))
-        self.assertEqual(x.evalf(), -1)
+        self.assertTrue(math.isclose(x.evalf(), -1))
 
         x = pi()
         self.assertTrue(isinstance(x, sp.Expr))
-        self.assertEqual(x.evalf(), math.pi)
+        self.assertTrue(math.isclose(x.evalf(), math.pi))
 
 
 # ---------------------------------------------------------------------------------------#


### PR DESCRIPTION
Fixes several issues that broke the testing workflow:
- a few assertEqual cases in tests, uses math.isclose for float values;
- a case where call to matplotlib's `add_collection3d` now requires items in `_segments3d` to have homogeneous shapes (breaking change introduced by matplotlib and numpy).
