### PR TITLE
[Issue-127] Pin version to match apt-installed python3-matplotlib

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v5
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,12 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
-          - os: macos-latest
-            python-version: "3.7"
-          - os: windows-latest
-            python-version: "3.7"
           - os: windows-latest
             python-version: "3.11"
           - os: windows-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,6 +22,8 @@ jobs:
           - os: macos-latest
             python-version: "3.7"
           - os: windows-latest
+            python-version: "3.7"
+          - os: windows-latest
             python-version: "3.11"
           - os: windows-latest
             python-version: "3.12"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -21,6 +21,10 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: "3.7"
+          - os: windows-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.12"
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ keywords = [
 ]
 
 dependencies = [
-    "numpy>=1.17.4",
+    "numpy>=1.17.4,<2", # Cannot use 2.0 due to matplotlib version pinning.
     "scipy",
-    "matplotlib",
+    "matplotlib==3.5.1", # Large user-base has apt-installed python3-matplotlib (ROS2) which is pinned to this version.
     "ansitable",
     "typing_extensions",
     "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 ]
 
 dependencies = [
-    "numpy>=1.17.4,<2", # Cannot use 2.0 due to matplotlib version pinning.
+    "numpy>=1.22,<2", # Cannot use 2.0 due to matplotlib version pinning.
     "scipy",
     "matplotlib==3.5.1", # Large user-base has apt-installed python3-matplotlib (ROS2) which is pinned to this version.
     "ansitable",


### PR DESCRIPTION
Pin matplotlib version in pyproject.toml so that the installation won’t cause issue in ROS2 setups where matplotlib has been apt-installed and hence pinned to version 3.5.1. This particular version pinning also results in a narrower numpy version range "numpy>=1.22,<2" and an end of support for python 3.7.

This PR is a WIP.

Tests done:
- [x] Testing workflow: all environments in test matrix are passing except for the following three, with error messages suggesting issues noted for each :
  - ubuntu + python 3.7, windows + python 3.7 (numpy does not have a version for this env);
  - windows + python 3.11, windows + python 3.12 (matplotlib does not provide a wheel for this env);
- [x] In ROS2 Humble docker (ref https://docs.ros.org/en/humble/How-To-Guides/Run-2-nodes-in-single-or-separate-docker-containers.html):
  - [x] spatialmath-python `pip install .` (from source) recognized the existing apt-installed matplotlib and kept it without overwriting;
  - [x] "import spatialmath" worked when we further narrowed down numpy version range, due to `TypeError: 'numpy._DTypeMeta' object is not subscriptable` issue.


NOTE: the other part of the discussion, i.e. the matplotlib related imports should better be confined to sub modules where plotting is actually needed, is not resolved by this PR.