### PR TITLE
Added constrained uniform sampling of angles for SE3, SO3, and Quaternions

### DIFF
--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -34,7 +34,7 @@ from spatialmath.pose2d import SE2
 
 from spatialmath.twist import Twist3
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from spatialmath.quaternion import UnitQuaternion
 
@@ -455,12 +455,16 @@ class SO3(BasePoseMatrix):
         return cls([smb.rotz(x, unit=unit) for x in smb.getvector(theta)], check=False)
 
     @classmethod
-    def Rand(cls, N: int = 1) -> Self:
+    def Rand(cls, N: int = 1, *, theta_range:Optional[ArrayLike2] = None, unit: str = "rad") -> Self:
         """
         Construct a new SO(3) from random rotation
 
         :param N: number of random rotations
         :type N: int
+        :param theta_range: anglular magnitude range [min,max], defaults to None.
+        :type xrange: 2-element sequence, optional
+        :param unit: angular units: 'rad' [default], or 'deg'
+        :type unit: str
         :return: SO(3) rotation matrix
         :rtype: SO3 instance
 
@@ -477,7 +481,7 @@ class SO3(BasePoseMatrix):
 
         :seealso: :func:`spatialmath.quaternion.UnitQuaternion.Rand`
         """
-        return cls([smb.q2r(smb.qrand()) for _ in range(0, N)], check=False)
+        return cls([smb.q2r(smb.qrand(theta_range=theta_range, unit=unit)) for _ in range(0, N)], check=False)
 
     @overload
     @classmethod
@@ -1517,6 +1521,8 @@ class SE3(SO3):
         xrange: Optional[ArrayLike2] = (-1, 1),
         yrange: Optional[ArrayLike2] = (-1, 1),
         zrange: Optional[ArrayLike2] = (-1, 1),
+        theta_range:Optional[ArrayLike2] = None,
+        unit: str = "rad",
     ) -> SE3:  # pylint: disable=arguments-differ
         """
         Create a random SE(3)
@@ -1527,6 +1533,10 @@ class SE3(SO3):
         :type yrange: 2-element sequence, optional
         :param zrange: z-axis range [min,max], defaults to [-1, 1]
         :type zrange: 2-element sequence, optional
+        :param theta_range: anglular magnitude range [min,max], defaults to None -> [0,pi].
+        :type xrange: 2-element sequence, optional
+        :param unit: angular units: 'rad' [default], or 'deg'
+        :type unit: str
         :param N: number of random transforms
         :type N: int
         :return: SE(3) matrix
@@ -1557,7 +1567,7 @@ class SE3(SO3):
         Z = np.random.uniform(
             low=zrange[0], high=zrange[1], size=N
         )  # random values in the range
-        R = SO3.Rand(N=N)
+        R = SO3.Rand(N=N, theta_range=theta_range, unit=unit)
         return cls(
             [smb.transl(x, y, z) @ smb.r2t(r.A) for (x, y, z, r) in zip(X, Y, Z, R)],
             check=False,

--- a/spatialmath/quaternion.py
+++ b/spatialmath/quaternion.py
@@ -1225,12 +1225,16 @@ class UnitQuaternion(Quaternion):
         )
 
     @classmethod
-    def Rand(cls, N: int = 1) -> UnitQuaternion:
+    def Rand(cls, N: int = 1, *, theta_range:Optional[ArrayLike2] = None, unit: str = "rad") -> UnitQuaternion:
         """
         Construct a new random unit quaternion
 
         :param N: number of random rotations
         :type N: int
+        :param theta_range: anglular magnitude range [min,max], defaults to None -> [0,pi].
+        :type xrange: 2-element sequence, optional
+        :param unit: angular units: 'rad' [default], or 'deg'
+        :type unit: str
         :return: random unit-quaternion
         :rtype: UnitQuaternion instance
 
@@ -1248,7 +1252,7 @@ class UnitQuaternion(Quaternion):
 
         :seealso: :meth:`UnitQuaternion.Rand`
         """
-        return cls([smb.qrand() for i in range(0, N)], check=False)
+        return cls([smb.qrand(theta_range=theta_range, unit=unit) for i in range(0, N)], check=False)
 
     @classmethod
     def Eul(cls, *angles: List[float], unit: Optional[str] = "rad") -> UnitQuaternion:

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -77,6 +77,12 @@ class TestSO3(unittest.TestCase):
         nt.assert_equal(len(R), 1)
         self.assertIsInstance(R, SO3)
 
+        R = SO3.Rand(theta_range=(0.1, 0.7))
+        self.assertIsInstance(R, SO3)
+        self.assertEqual(R.A.shape, (3, 3))
+        self.assertLessEqual(R.angvec()[0], 0.7)
+        self.assertGreaterEqual(R.angvec()[0], 0.1)
+
         # copy constructor
         R = SO3.Rx(pi / 2)
         R2 = SO3(R)
@@ -835,6 +841,13 @@ class TestSE3(unittest.TestCase):
         nt.assert_equal(T.x, t[0])
         nt.assert_equal(T.y, t[1])
         nt.assert_equal(T.z, t[2])
+
+        # random
+        T = SE3.Rand(theta_range=(0.1, 0.7))
+        self.assertIsInstance(T, SE3)
+        self.assertEqual(T.A.shape, (4, 4))
+        self.assertLessEqual(T.angvec()[0], 0.7)
+        self.assertGreaterEqual(T.angvec()[0], 0.1)
 
         TT = SE3([T, T, T])
         desired_shape = (3,)

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -72,6 +72,7 @@ class TestSO3(unittest.TestCase):
         array_compare(R, np.eye(3))
         self.assertIsInstance(R, SO3)
 
+        np.random.seed(32)
         # random
         R = SO3.Rand()
         nt.assert_equal(len(R), 1)
@@ -822,6 +823,7 @@ class TestSE3(unittest.TestCase):
         array_compare(R, np.eye(4))
         self.assertIsInstance(R, SE3)
 
+        np.random.seed(65)
         # random
         R = SE3.Rand()
         nt.assert_equal(len(R), 1)

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -78,6 +78,7 @@ class TestSO3(unittest.TestCase):
         nt.assert_equal(len(R), 1)
         self.assertIsInstance(R, SO3)
 
+        # random constained
         R = SO3.Rand(theta_range=(0.1, 0.7))
         self.assertIsInstance(R, SO3)
         self.assertEqual(R.A.shape, (3, 3))
@@ -829,7 +830,7 @@ class TestSE3(unittest.TestCase):
         nt.assert_equal(len(R), 1)
         self.assertIsInstance(R, SE3)
 
-        # random
+        # random 
         T = SE3.Rand()
         R = T.R
         t = T.t
@@ -844,13 +845,6 @@ class TestSE3(unittest.TestCase):
         nt.assert_equal(T.y, t[1])
         nt.assert_equal(T.z, t[2])
 
-        # random
-        T = SE3.Rand(theta_range=(0.1, 0.7))
-        self.assertIsInstance(T, SE3)
-        self.assertEqual(T.A.shape, (4, 4))
-        self.assertLessEqual(T.angvec()[0], 0.7)
-        self.assertGreaterEqual(T.angvec()[0], 0.1)
-
         TT = SE3([T, T, T])
         desired_shape = (3,)
         nt.assert_equal(TT.x.shape, desired_shape)
@@ -861,6 +855,13 @@ class TestSE3(unittest.TestCase):
         nt.assert_equal(TT.x, ones * t[0])
         nt.assert_equal(TT.y, ones * t[1])
         nt.assert_equal(TT.z, ones * t[2])
+
+        # random constained
+        T = SE3.Rand(theta_range=(0.1, 0.7))
+        self.assertIsInstance(T, SE3)
+        self.assertEqual(T.A.shape, (4, 4))
+        self.assertLessEqual(T.angvec()[0], 0.7)
+        self.assertGreaterEqual(T.angvec()[0], 0.1)
 
         # copy constructor
         R = SE3.Rx(pi / 2)

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -48,6 +48,13 @@ class TestUnitQuaternion(unittest.TestCase):
         nt.assert_array_almost_equal(
             UnitQuaternion.Rz(-90, "deg").vec, np.r_[1, 0, 0, -1] / math.sqrt(2)
         )
+        
+        np.random.seed(73)
+        q = UnitQuaternion.Rand(theta_range=(0.1, 0.7))
+        self.assertIsInstance(q, UnitQuaternion)
+        self.assertLessEqual(q.angvec()[0], 0.7)
+        self.assertGreaterEqual(q.angvec()[0], 0.1)
+
 
         q = UnitQuaternion.Rand(theta_range=(0.1, 0.7))
         self.assertIsInstance(q, UnitQuaternion)

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -49,6 +49,12 @@ class TestUnitQuaternion(unittest.TestCase):
             UnitQuaternion.Rz(-90, "deg").vec, np.r_[1, 0, 0, -1] / math.sqrt(2)
         )
 
+        q = UnitQuaternion.Rand(theta_range=(0.1, 0.7))
+        self.assertIsInstance(q, UnitQuaternion)
+        self.assertLessEqual(q.angvec()[0], 0.7)
+        self.assertGreaterEqual(q.angvec()[0], 0.1)
+
+
     def test_constructor(self):
         qcompare(UnitQuaternion(), [1, 0, 0, 0])
 


### PR DESCRIPTION
## Change Overview

Added constrained uniform sampling of angles for SE3, SO3, and Quaternions based. Samling respects the distribution of orientations at different magnitudes and samples accordingly using the analytical CDF and Inverse Transform Sampling. Interpolation is used for fast inverses of the CDF. Derivation of CDF can be found here: [Uniform_Rotation_Distributions.pdf](https://github.com/user-attachments/files/17319541/Uniform_Rotation_Distributions.pdf).

## Testing Done
Pose based unit tests pass.

Empirically checked distribution against rejection sampling. 
![image](https://github.com/user-attachments/assets/ff5c8e0c-d784-4cc8-9274-7f0006983a8b)
![image](https://github.com/user-attachments/assets/cf948605-d417-404b-a38e-c09f834a67d5)
