### PR TITLE
Fix string equality warnings in `SplineFit` class

### DIFF
--- a/spatialmath/spline.py
+++ b/spatialmath/spline.py
@@ -192,14 +192,14 @@ class SplineFit:
             )
 
             sample_time = self.time_data[candidate_removal_index]
-            if check_type is "local":
+            if check_type == "local":
                 angular_error = SO3(self.pose_data[candidate_removal_index]).angdist(
                     SO3(self.spline.spline_so3(sample_time).as_matrix())
                 )
                 euclidean_error = np.linalg.norm(
                     self.pose_data[candidate_removal_index].t - self.spline.spline_xyz(sample_time)
                 )
-            elif check_type is "global":
+            elif check_type == "global":
                 angular_error = self.max_angular_error()
                 euclidean_error = self.max_euclidean_error()
             else:


### PR DESCRIPTION
We've started getting some loud warnings about using `is` instead of `==` when checking string values.

```
/usr/local/lib/python3.10/dist-packages/spatialmath/spline.py:195: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if check_type is "local":
/usr/local/lib/python3.10/dist-packages/spatialmath/spline.py:202: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif check_type is "global":
```

This small PR should resolve that.

Closes #146 