### PR TITLE
[SW-1712] Pin ubuntu version in workflows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-22.04, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: windows-latest
@@ -44,7 +44,7 @@ jobs:
     # If all tests pass:
     # Run coverage and upload to codecov
     needs: unittest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         python-version: [3.8]
 
     steps:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   sphinx:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event_name != 'pull_request' }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Change Overview

This is simply a find/replace of `ubuntu-latest` -> `ubuntu-22.04`.  Because `ubuntu-latest` will become 24.04 soon.  We should pin to 22.04 which matches our development environment.

## Testing Done

None. This PR is the test.  (Assuming this repo has CI)

