### PR TITLE
Optional deps humble

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ Install a snapshot from PyPI
 pip install spatialmath-python
 ```
 
+Note that if you are using ROS2, you may run into version conflicts when using `rosdep`, particularly
+concerning `matplotlib`. If this happens, you can enable optional version pinning with
+
+```
+pip install spatialmath-python[ros-humble]
+```
+
 ## From GitHub
 
 Install the current code base from GitHub and pip install a link to that cloned copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ keywords = [
 dependencies = [
     "numpy>=1.22,<2", # Cannot use 2.0 due to matplotlib version pinning.
     "scipy",
-    "matplotlib==3.5.1", # Large user-base has apt-installed python3-matplotlib (ROS2) which is pinned to this version.
+    "matplotlib",
     "ansitable",
     "typing_extensions",
     "pre-commit",
@@ -68,6 +68,10 @@ docs = [
     "sphinxcontrib-jsmath", 
     "sphinx-favicon",
     "sphinx-autodoc-typehints",
+]
+
+ROS2-humble = [
+    "matplotlib==3.5.1", # Large user-base has apt-installed python3-matplotlib (ROS2) which is pinned to this version.
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keywords = [
 ]
 
 dependencies = [
-    "numpy>=1.22,<2", # Cannot use 2.0 due to matplotlib version pinning.
+    "numpy>=1.22",
     "scipy",
     "matplotlib",
     "ansitable",
@@ -70,8 +70,9 @@ docs = [
     "sphinx-autodoc-typehints",
 ]
 
-ROS2-humble = [
+ros-humble = [
     "matplotlib==3.5.1", # Large user-base has apt-installed python3-matplotlib (ROS2) which is pinned to this version.
+    "numpy<2", # Cannot use 2.0 due to matplotlib version pinning.
 ]
 
 [build-system]


### PR DESCRIPTION
Previously, we added version pinning by default for `matplotlib` and `numpy`, to avoid conflicts with system-installed packages in ROS2. This PR removes the default version pinning, moving to a `ros-humble` under `project.optional-dependencies` in `pyproject.toml`.

Now, to avoid version conflicts under ROS2 (Humble), the package can be installed via

```
pip install spatialmath-python[ros-humble]
```

and the `README.md` is updated to reflect this.

Tested that:
- adding `[ros-humble]` to the installation command enforces ROS-compatible library versions, avoiding conflict;
- installing without `[ros-humble]` installs up-to-date versions of the libraries. 