### PR TITLE
fix bug where `getunit` converts a scalar argument to a 0d numpy array

### DIFF
--- a/spatialmath/base/argcheck.py
+++ b/spatialmath/base/argcheck.py
@@ -559,7 +559,7 @@ def getunit(v: ArrayLike, unit: str = "rad", dim=None) -> Union[float, NDArray]:
 
     :seealso: :func:`getvector`
     """
-    if not isinstance(v, Iterable) and dim == 0:
+    if not isinstance(v, Iterable) and dim in (0, None):
         # scalar in, scalar out
         if unit == "rad":
             return v


### PR DESCRIPTION
The problem in #144 is actually in `getunit` which returns a numpy array when passed a scalar.  This is a more general problem that was picked up here.

The fix is simple.  Tested by turning warnings on

```
% python -Wd
Python 3.10.16 (main, Dec 11 2024, 10:22:29) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from spatialmath.base import angvec2r
>>> angvec2r(0.3, [1, 0, 0])
array([[ 1.        ,  0.        ,  0.        ],
       [ 0.        ,  0.95533649, -0.29552021],
       [ 0.        ,  0.29552021,  0.95533649]])
>>> 
```