### PR TITLE
Configure black to use specific version (23), for consistency across all users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ packages = [
 ]
 
 [tool.black]
+required-version = 23
 line-length = 88
 target-version = ['py38']
 exclude = "camera_derivatives.py"


### PR DESCRIPTION
One part of solving the black versioning problem for the repo.  Black by default takes the version number from `pyproject.toml` if it can find it.