### PR TITLE
Fix the intersphinx source for matplotlib.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -187,7 +187,7 @@ np.set_printoptions(precision=4, suppress=True)
 intersphinx_mapping = {
     "numpy": ("http://docs.scipy.org/doc/numpy/", None),
     "scipy": ("http://docs.scipy.org/doc/scipy/reference/", None),
-    "matplotlib": ("http://matplotlib.sourceforge.net/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
 # -------- Options favicon -------------------------------------------------------#


### PR DESCRIPTION
Changed by the matplotlib project.  This source allows referencing of `matplotlib` classes and methods from spatial math doco.