### PR TITLE
Add methods to convert SE3 to/from the rvec, tvec format used by OpenCV

### DIFF
--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -1292,6 +1292,21 @@ class SE3(SO3):
         else:
             return smb.tr2delta(self.A, X2.A)
 
+    def rtvec(self) -> Tuple[R3, R3]:
+        """
+        Convert to OpenCV-style rotation and translation vectors
+
+        :return: rotation and translation vectors
+        :rtype: ndarray(3), ndarray(3)
+
+        Many OpenCV functions accept pose as two 3-vectors: a rotation vector using
+        exponential coordinates and a translation vector.  This method combines them
+        into an SE(3) instance.
+
+        :seealso: :meth:`rtvec`
+        """
+        return SO3(self).log(twist=True), self.t
+
     def Ad(self) -> R6x6:
         r"""
         Adjoint of SE(3)
@@ -1832,6 +1847,26 @@ class SE3(SO3):
             return cls(smb.trexp(smb.getvector(S)), check=False)
         else:
             return cls(smb.trexp(S), check=False)
+
+    @classmethod
+    def RTvec(cls, rvec: ArrayLike3, tvec: ArrayLike3) -> Self:
+        """
+        Construct a new SE(3) from OpenCV-style rotation and translation vectors
+
+        :param rvec: rotation as exponential coordinates
+        :type rvec: ArrayLike3
+        :param tvec: translation vector
+        :type tvec: ArrayLike3
+        :return: An SE(3) instance
+        :rtype: SE3 instance
+
+        Many OpenCV functions (such as pose estimation) return pose as two 3-vectors: a
+        rotation vector using exponential coordinates and a translation vector.  This
+        method combines them into an SE(3) instance.
+
+        :seealso: :meth:`rtvec`
+        """
+        return SE3.Rt(smb.trexp(rvec), tvec)
 
     @classmethod
     def Delta(cls, d: ArrayLike6) -> SE3:

--- a/tests/test_pose3d.py
+++ b/tests/test_pose3d.py
@@ -254,7 +254,6 @@ class TestSO3(unittest.TestCase):
         nt.assert_array_almost_equal(q.SO3(), R_from_q)
         nt.assert_array_almost_equal(q.SO3().UnitQuaternion(), q)
 
-
     def test_shape(self):
         a = SO3()
         self.assertEqual(a._A.shape, a.shape)
@@ -1338,6 +1337,16 @@ class TestSE3(unittest.TestCase):
         # inv
         # .T
         pass
+
+    def test_rtvec(self):
+        # OpenCV compatibility functions
+        T = SE3.RTvec([0, 1, 0], [2, 3, 4])
+        nt.assert_equal(T.t, [2, 3, 4])
+        nt.assert_equal(T.R, SO3.Ry(1))
+
+        rvec, tvec = T.rtvec()
+        nt.assert_equal(rvec, [0, 1, 0])
+        nt.assert_equal(tvec, [2, 3, 4])
 
 
 # ---------------------------------------------------------------------------------------#


### PR DESCRIPTION
OpenCV represents poses by a pair of 3-vectors: rvec (exponential coordinates) and tvec (translation).  Two new methods: construct an SE3 from rvec, tvec, and convert SE3 to rvec, tvec.

Tests and doco included.